### PR TITLE
[PR] build.sh does not package on compile errors.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,19 +1,19 @@
 rm -f ./VimFx.xpi
 
-coffee -c --bare \
-    extension/bootstrap.coffee \
-    extension/packages/*.coffee \
-    extension/includes/*.coffee
-
-cd extension
-zip -r ../VimFx.xpi \
-    bootstrap.js \
-    chrome.manifest \
-    icon.png \
-    install.rdf \
-    options.xul \
-    includes/*.js \
-    packages/*.js \
-    resources/* \
-    locale
-cd ..
+coffee -c --bare                   \
+    extension/bootstrap.coffee     \
+    extension/packages/*.coffee    \
+    extension/includes/*.coffee && \
+                                   \
+  cd extension                  && \
+  zip -r ../VimFx.xpi              \
+      bootstrap.js                 \
+      chrome.manifest              \
+      icon.png                     \
+      install.rdf                  \
+      options.xul                  \
+      includes/*.js                \
+      packages/*.js                \
+      resources/*                  \
+      locale                    && \
+  cd ..


### PR DESCRIPTION
This is useful for smaller terminals where the packaging output (zip)
would scroll the terminal, preventing the developer from noticing the
compiler errors.

The formatting of build.sh is changed slightly for readability in
accommodation with this change.
