### PR TITLE
Don't close pinned tabs when pressing x

### DIFF
--- a/extension/packages/commands.coffee
+++ b/extension/packages/commands.coffee
@@ -166,7 +166,8 @@ command_L = (vim) ->
 # Close current tab
 command_x = (vim) ->
   if rootWindow = utils.getRootWindow vim.window
-    rootWindow.gBrowser.removeCurrentTab()
+    unless rootWindow.gBrowser.selectedTab.pinned
+      rootWindow.gBrowser.removeCurrentTab()
 
 # Restore last closed tab
 command_X = (vim) -> 


### PR DESCRIPTION
Firefox doesn't allow closing pinned tabs with a GUI button nor by
pressing Ctrl+W. This commit introduces similar behaviour in VimFx.
Pinned tabs won't be closed by pressing x.
