### PR TITLE
Add markers for embedded objects.

### DIFF
--- a/extension/packages/marker.coffee
+++ b/extension/packages/marker.coffee
@@ -26,6 +26,8 @@ MARKABLE_ELEMENTS = [
   "button" 
   "select"
   "input[not(@type='hidden' or @disabled or @readonly)]"
+  "embed"
+  "object"
 ]
 
 


### PR DESCRIPTION
This partially fixes issue #92.

In click-to-play mode, `<embed>` objects can be activated via context menu: Alt, c.
