### PR TITLE
Fix Market.getElementRect function.

### DIFF
--- a/extension/packages/marker.coffee
+++ b/extension/packages/marker.coffee
@@ -231,10 +231,10 @@ getElementRect = (element) ->
     if rect.width == 0 or rect.height == 0
       for childElement in element.children
         computedStyle = window.getComputedStyle childElement, null
-        if computedStyle.getPropertyValue 'float' != 'none' or \
-           computedStyle.getPropertyValue 'position' == 'absolute'
+        if computedStyle.getPropertyValue('float') != 'none' or \
+           computedStyle.getPropertyValue('position') == 'absolute'
 
-          childRect if childRect = getElementRect childElement
+          return childRect if childRect = getElementRect childElement
 
   return undefined
 


### PR DESCRIPTION
The current coffee code compiles to the following javascript code:

```
    if (computedStyle.getPropertyValue('float' !== 'none' || computedStyle.getPropertyValue('position' === 'absolute'))) {
      if (childRect = getElementRect(childElement)) {
        childRect;
      }
    }
    return void 0;
```

That is obviously not the expected behavior.
