### PR TITLE
Use Huffman algorithm for hints generation (fix #112)

### DIFF
--- a/extension/locale/en-US/options.dtd
+++ b/extension/locale/en-US/options.dtd
@@ -1,8 +1,8 @@
 <!ENTITY pref.hint_chars.title      "Hint Chars">
-<!ENTITY pref.hint_chars.desc       "Default: asdfgercvhjkl;uinm">
+<!ENTITY pref.hint_chars.desc       "Default: fjdksla;ghrueiwovncm">
 
 <!ENTITY pref.black_list.title      "Black List">
-<!ENTITY pref.black_list.desc       "Comma separated list of URL where VimFx should be automatically disabled. 
+<!ENTITY pref.black_list.desc       "Comma separated list of URL where VimFx should be automatically disabled.
 Wildcards allowed: *, !">
 
 <!ENTITY pref.scroll_step.title     "Scroll Step">

--- a/extension/locale/hu-HU/options.dtd
+++ b/extension/locale/hu-HU/options.dtd
@@ -1,5 +1,5 @@
 <!ENTITY pref.hint_chars.title      "Segéd karakterek">
-<!ENTITY pref.hint_chars.desc       "Alapértelmezett: asdfgercvhjkl;uinm">
+<!ENTITY pref.hint_chars.desc       "Alapértelmezett: fjdksla;ghrueiwovncm">
 
 <!ENTITY pref.black_list.title      "Fekete lista">
 <!ENTITY pref.black_list.desc       "Vesszővel elválasztott URL-ek, ahol a VimFX inaktív legyen

--- a/extension/locale/hu/options.dtd
+++ b/extension/locale/hu/options.dtd
@@ -1,5 +1,5 @@
 <!ENTITY pref.hint_chars.title      "Segéd karakterek">
-<!ENTITY pref.hint_chars.desc       "Alapértelmezett: asdfgercvhjkl;uinm">
+<!ENTITY pref.hint_chars.desc       "Alapértelmezett: fjdksla;ghrueiwovncm">
 
 <!ENTITY pref.black_list.title      "Fekete lista">
 <!ENTITY pref.black_list.desc       "Vesszővel elválasztott URL-ek, ahol a VimFX inaktív legyen. Helyettesítő karakterek is használhatók: *, !">

--- a/extension/locale/nl/options.dtd
+++ b/extension/locale/nl/options.dtd
@@ -1,5 +1,5 @@
 <!ENTITY pref.hint_chars.title      "Gebruikte karakters">
-<!ENTITY pref.hint_chars.desc       "Standaard: asdfgercvhjkl;uinm">
+<!ENTITY pref.hint_chars.desc       "Standaard: fjdksla;ghrueiwovncm">
 
 <!ENTITY pref.black_list.title      "Zwarte lijst">
 <!ENTITY pref.black_list.desc       "Door komma's gescheiden lijst van adressen waarop VimFx automatisch uitgeschakeld moet worden.

--- a/extension/locale/pl/options.dtd
+++ b/extension/locale/pl/options.dtd
@@ -1,5 +1,5 @@
 <!ENTITY pref.hint_chars.title      "Znaki podpowiedzi">
-<!ENTITY pref.hint_chars.desc       "Domyślnie: asdfgercvhjkl;uinm">
+<!ENTITY pref.hint_chars.desc       "Domyślnie: fjdksla;ghrueiwovncm">
 
 <!ENTITY pref.black_list.title      "Czarna lista">
 <!ENTITY pref.black_list.desc       "Lista adresów oddzielonych przecinkami pod którymi VimFx powinien być automatycznie wyłączony.

--- a/extension/locale/ru/options.dtd
+++ b/extension/locale/ru/options.dtd
@@ -1,8 +1,8 @@
 <!ENTITY pref.hint_chars.title      "Символы на маркерах">
-<!ENTITY pref.hint_chars.desc       "По умолчанию: asdfgercvhjkl;uinm">
+<!ENTITY pref.hint_chars.desc       "По умолчанию: fjdksla;ghrueiwovncm">
 
 <!ENTITY pref.black_list.title      "Стоп список">
-<!ENTITY pref.black_list.desc       "Список адесов, разделенных запятой, на которых VimFx не активен. 
+<!ENTITY pref.black_list.desc       "Список адесов, разделенных запятой, на которых VimFx не активен.
 Разрешены одстановки: *, !">
 
 <!ENTITY pref.scroll_step.title     "Шаг прокрутки страницы">

--- a/extension/locale/zh-CN/options.dtd
+++ b/extension/locale/zh-CN/options.dtd
@@ -1,5 +1,5 @@
 <!ENTITY pref.hint_chars.title      "提示符（Hint Chars）">
-<!ENTITY pref.hint_chars.desc       "默认：asdfgercvhjkl;uinm">
+<!ENTITY pref.hint_chars.desc       "默认：fjdksla;ghrueiwovncm">
 
 <!ENTITY pref.black_list.title      "黑名单">
 <!ENTITY pref.black_list.desc       "当访问列表中的 URL（逗号分隔）时，VimFx 将被自动禁用。

--- a/extension/packages/events.coffee
+++ b/extension/packages/events.coffee
@@ -19,7 +19,7 @@ suppressEvent = (event) ->
 
 keyStrFromEvent = (event) ->
 
-  { ctrlKey: ctrl, metaKey: meta, altKey: alt, shiftKey: shift } = event 
+  { ctrlKey: ctrl, metaKey: meta, altKey: alt, shiftKey: shift } = event
 
   if !meta and !alt
     if keyChar = keyUtils.keyCharFromCode(event.keyCode, shift)
@@ -27,24 +27,24 @@ keyStrFromEvent = (event) ->
 
   return keyStr
 
-# Passthrough mode is activated when VimFx should temporarily stop processking 
+# Passthrough mode is activated when VimFx should temporarily stop processking
 # keyboard input. For example when a context menu is whown
 passthrough = false
 
 # The following listeners are installed on every top level Chrome window
-windowsListener = 
+windowsListener =
   'keydown': (event) ->
 
-    if passthrough or getPref 'disabled' 
+    if passthrough or getPref 'disabled'
       return
 
     try
       isEditable = utils.isElementEditable event.originalTarget
 
-      keyStr = keyStrFromEvent(event) 
+      keyStr = keyStrFromEvent(event)
 
       # We only handle the key if it's recognized by `keyCharFromCode`
-      # and if there is no focused editable element # or if it's the *Esc* key, 
+      # and if there is no focused editable element # or if it's the *Esc* key,
       # which will remove the focus from the currently focused element
       if keyStr and (not isEditable or keyStr == 'Esc')
         if window = utils.getCurrentTabWindow event
@@ -75,8 +75,8 @@ windowsListener =
           # No action on blacklisted locations
           if vim.blacklisted
             return
-          
-          # Blur from any active element on Esc. Calling before `handleKeyPress` 
+
+          # Blur from any active element on Esc. Calling before `handleKeyPress`
           # because `vim.keys` will be reset afterwards`
           blur_on_esc = vim.lastKeyStr == 'Esc' and getPref 'blur_on_esc'
 
@@ -116,7 +116,7 @@ windowsListener =
     if event.target.tagName in [ 'menupopup', 'panel' ]
       passthrough = false
 
-  # When the top level window closes we should release all Vims that were 
+  # When the top level window closes we should release all Vims that were
   # associated with tabs in this window
   'DOMWindowClose': (event) ->
     if gBrowser = event.originalTarget.gBrowser
@@ -138,7 +138,7 @@ windowsListener =
 # This listener works on individual tabs within Chrome Window
 # User for: listening for location changes and disabling the extension
 # on black listed urls
-tabsListener = 
+tabsListener =
   onLocationChange: (browser, webProgress, request, location) ->
     blacklisted = utils.isBlacklisted location.spec, getPref 'black_list'
     if vim = vimBucket.get(browser.contentWindow)
@@ -158,7 +158,7 @@ addEventListeners = (window) ->
     for name, listener of windowsListener
       window.removeEventListener name, listener, true
 
-  unload -> 
+  unload ->
     removeEventListeners window
     window.gBrowser.removeTabsProgressListener tabsListener
 

--- a/extension/packages/huffman.coffee
+++ b/extension/packages/huffman.coffee
@@ -1,0 +1,58 @@
+# `originalElements` should be an array of arrays. The first item of each sub-array should be a
+# _weight_, which is a positive number. The sub-arrays may then contain whatever data that should be
+# associated with the weight and the _code word_ which will be appended to each sub-array. The
+# larger the weight, the shorter the code word. The code words will use the `{alphabet}` provided.
+# Note that the function modifies the `originalElements` array and returns `null`.
+exports.addHuffmanCodeWordsTo = (originalElements, {alphabet}) ->
+	if typeof alphabet isnt 'string'
+		throw new TypeError '`alphabet` must be a string.'
+
+	nonUnique = /([\s\S])[\s\S]*\1/.exec alphabet
+	if nonUnique
+		throw new Error "`alphabet` must consist of unique letters. Found '#{nonUnique[1]}' more than once."
+
+	if alphabet.length < 2
+		throw new Error '`alphabet` must consist of at least 2 characters.'
+
+	elements = ({index, weight} for [weight], index in originalElements)
+
+	numBranches = alphabet.length
+	numElements = elements.length
+	# A `numBranches`-ary tree can be formed by `1 + (numBranches - 1) * n` elements (there needs to
+	# be 1 element left, and each parent node replaces `numBranches` other nodes). `n` is the number
+	# of points where the tree branches. If numElements does not exist in mentioned set, we have to
+	# pad it to the nearest larger such number. Thus, we need to find an `n` such that `1 +
+	# (numBranches - 1) * n >= numElements`. Solving for `n = numBranchPoints` gives:
+	numBranchPoints = Math.ceil (numElements - 1) / (numBranches - 1)
+	# It is required that `(numElements + padding) - (numBranches - 1) * numBranchPoints == 1` (see
+	# above). Otherwise we cannot form a `numBranches`-ary tree. Solving for `padding` gives:
+	padding = 1 + (numBranches - 1) * numBranchPoints - numElements
+
+	# Pad with zero-weights to be able to form a `numBranches` tree.
+	for i in [0...padding] by 1
+		elements.push {weight: 0}
+
+	# Construct the Huffman tree.
+	for i in [0...numBranchPoints] by 1
+		# Sort the weights in descending order, so that the last ones will be the ones with lowest
+		# weight.
+		elements.sort (a, b) -> b.weight - a.weight
+
+		# Replace `numBranches` weights with their sum.
+		sum = {weight: 0, children: []}
+		for i in [0...numBranches] by 1
+			lowestWeight = elements.pop()
+			sum.weight += lowestWeight.weight
+			sum.children.unshift lowestWeight
+		elements.push sum
+
+	root = elements[0] # `elements.length is 1` by now.
+
+	# Create the code words by walking the tree.
+	do walk = (node=root, codeWord='') ->
+		if node.children
+			for childNode, index in node.children
+				walk childNode, codeWord + alphabet[index]
+		else
+			originalElements[node.index].push codeWord  unless node.weight is 0
+		null

--- a/extension/packages/prefs.coffee
+++ b/extension/packages/prefs.coffee
@@ -3,11 +3,11 @@
 PREF_BRANCH = "extensions.VimFx.";
 
 # Default values for the preference
-# All used preferences should be mentioned here becuase 
+# All used preferences should be mentioned here becuase
 # preference type is derived from here
-DEFAULT_PREF_VALUES = 
+DEFAULT_PREF_VALUES =
   addon_id:       'VimFx@akhodakivskiy.github.com'
-  hint_chars:     'asdfgercvhjkl;uinm'
+  hint_chars:     'fjdksla;ghrueiwovncm'
   disabled:       false
   scroll_step:    60
   scroll_time:    100
@@ -32,7 +32,7 @@ getBranchPref = (branch, key, defaultValue) ->
 getPref = do ->
   prefs = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService)
   branch = prefs.getBranch PREF_BRANCH
-  
+
   return (key, defaultValue=undefined) ->
     value = getBranchPref branch, key, defaultValue
     return if value == undefined then getDefaultPref(key) else value
@@ -42,7 +42,7 @@ getDefaultPref = (key) -> return DEFAULT_PREF_VALUES[key]
 getFirefoxPref = do ->
   prefs = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService)
   branch = prefs.getBranch ''
-  
+
   return (key, defaultValue=undefined) ->
     return getBranchPref branch, key, defaultValue
 

--- a/extension/packages/utils.coffee
+++ b/extension/packages/utils.coffee
@@ -13,7 +13,7 @@ ChromeWindow        = Ci.nsIDOMChromeWindow
 _sss  = Cc["@mozilla.org/content/style-sheet-service;1"].getService(Ci.nsIStyleSheetService)
 _clip = Cc["@mozilla.org/widget/clipboard;1"].getService(Ci.nsIClipboard)
 
-{ getPref 
+{ getPref
 , getDefaultPref
 } = require 'prefs'
 
@@ -41,16 +41,16 @@ getCurrentTabWindow = (event) ->
 getEventWindow = (event) ->
   if event.originalTarget instanceof Window
     return event.originalTarget
-  else 
+  else
     doc = event.originalTarget.ownerDocument or event.originalTarget
     if doc instanceof HTMLDocument or doc instanceof XULDocument
-      return doc.defaultView 
+      return doc.defaultView
 
 getEventRootWindow = (event) ->
   if window = getEventWindow event
     return getRootWindow window
 
-getEventTabBrowser = (event) -> 
+getEventTabBrowser = (event) ->
   cw.gBrowser if cw = getEventRootWindow event
 
 getRootWindow = (window) ->
@@ -59,7 +59,7 @@ getRootWindow = (window) ->
                .QueryInterface(Ci.nsIDocShellTreeItem)
                .rootTreeItem
                .QueryInterface(Ci.nsIInterfaceRequestor)
-               .getInterface(Window); 
+               .getInterface(Window);
 
 isTextInputElement = (element) ->
   return element instanceof HTMLInputElement or \
@@ -97,7 +97,7 @@ loadCss = (name) ->
   if !_sss.sheetRegistered(uri, _sss.AGENT_SHEET)
     _sss.loadAndRegisterSheet(uri, _sss.AGENT_SHEET)
 
-  unload -> 
+  unload ->
     _sss.unregisterSheet(uri, _sss.AGENT_SHEET)
 
 # Simulate mouse click with full chain of event
@@ -138,7 +138,7 @@ writeToClipboard = (window, text) ->
 readFromClipboard = (window) ->
   trans = Cc["@mozilla.org/widget/transferable;1"].createInstance(Ci.nsITransferable);
 
-  if trans.init 
+  if trans.init
     privacyContext = window.QueryInterface(Ci.nsIInterfaceRequestor)
       .getInterface(Ci.nsIWebNavigation)
       .QueryInterface(Ci.nsILoadContext);
@@ -172,7 +172,7 @@ timeIt = (func, msg) ->
 # `blackList`: comma/space separated list of URLs with wildcards (* and !)
 isBlacklisted = (str, blackList) ->
   for rule in blackList.split(/[\s,]+/)
-    rule = rule.replace(/\*/g, '.*').replace(/\!/g, '.') 
+    rule = rule.replace(/\*/g, '.*').replace(/\!/g, '.')
     if str.match new RegExp("^#{ rule }$")
       return true
 
@@ -196,7 +196,7 @@ smoothScroll = (window, dx, dy, msecs) ->
     window.scrollBy dx, dy
   else
     # Callback
-    fn = (_x, _y) -> 
+    fn = (_x, _y) ->
       window.scrollBy(_x, _y)
     # Number of steps
     delta = 10
@@ -238,10 +238,10 @@ browserSearchSubmission = (str) ->
 # will formed (without extra spaces at the tails)
 addClass = (element, klass) ->
   if (element.className?.search klass) == -1
-    if element.className 
+    if element.className
       element.className += " #{ klass }"
     else
-      element.className = klass 
+      element.className = klass
 
 # Remove a class from the `element.className`
 removeClass = (element, klass) ->
@@ -261,7 +261,7 @@ getHintChars = do ->
 
   return ->
     hintChars = removeDuplicateCharacters(getPref('hint_chars'))
-    if hintChars.length < 3
+    if hintChars.length < 2
       hintChars = getDefaultPref('hint_chars')
 
     return hintChars
@@ -292,4 +292,4 @@ exports.isURL                     = isURL
 exports.browserSearchSubmission   = browserSearchSubmission
 exports.addClass                  = addClass
 exports.removeClass               = removeClass
-exports.getHintChars              = getHintChars 
+exports.getHintChars              = getHintChars


### PR DESCRIPTION
The Huffman algorithm is now used to generate optimal prefix codes for all
focusable elements. The area of each element is used as _weight_. The
higher the weight, the shorter the hint.

Note:

The old algorithm seemed to give shorter hints to `<a>` elements. That is
currently not the case with the new algorithm.

Other related changes:
- Change minimum allowed number of hint chars from 3 to 2, since the new
  algorithm supports it.
- Change default hint chars, since with the new algorithm the best keys
  should be at the beginning of the string.
- My editor is set to strip trailing white space. Apparently there was a
  lot of trailing whitespace in many files, so a diff of this commit is a
  bit messy.
