### PR TITLE
Use element.classList instead of custom helpers

### DIFF
--- a/extension/packages/find.coffee
+++ b/extension/packages/find.coffee
@@ -1,5 +1,3 @@
-utils = require 'utils'
-
 CONTAINER_ID = 'VimFxFindContainer'
 DIRECTION_FORWARDS = 0
 DIRECTION_BACKWARDS = 1
@@ -16,9 +14,9 @@ injectFind = (document, cb) ->
   input.addEventListener 'input', (event) ->
     result = cb(input.value)
     if result
-      utils.removeClass input, 'VimFxNotFound'
+      input.classList.remove 'VimFxNotFound'
     else
-      utils.addClass input, 'VimFxNotFound'
+      input.classList.add 'VimFxNotFound'
 
   # Call back on (Shift)-Enter with proper direction
   input.addEventListener 'keypress', (event) ->
@@ -72,7 +70,7 @@ findFactory = (selectionType) ->
               .QueryInterface(Components.interfaces.nsIFind)
 
   return (window, findStr, findRng = null, direction = DIRECTION_FORWARDS, focus = false) ->
-    # `find` will also recursively search in all frames.  # `innerFind` does the work: 
+    # `find` will also recursively search in all frames.  # `innerFind` does the work:
     # searches, selects, scrolls, and optionally reaches into frames
     innerFind = (window) ->
       if controller = getController(window)
@@ -107,9 +105,9 @@ findFactory = (selectionType) ->
     if findStr.length > 0
       # Get all embedded windows/frames including the passed window
       wnds = getAllWindows window
-      # In backward searching reverse windows mode so that 
+      # In backward searching reverse windows mode so that
       # it starts off the deepest iframe
-      if finder.findBackwards 
+      if finder.findBackwards
         wnds.reverse()
 
       # First search in the same window to which current `findRng` belongs

--- a/extension/packages/utils.coffee
+++ b/extension/packages/utils.coffee
@@ -13,7 +13,7 @@ ChromeWindow        = Ci.nsIDOMChromeWindow
 _sss  = Cc["@mozilla.org/content/style-sheet-service;1"].getService(Ci.nsIStyleSheetService)
 _clip = Cc["@mozilla.org/widget/clipboard;1"].getService(Ci.nsIClipboard)
 
-{ getPref 
+{ getPref
 , getDefaultPref
 } = require 'prefs'
 
@@ -41,16 +41,16 @@ getCurrentTabWindow = (event) ->
 getEventWindow = (event) ->
   if event.originalTarget instanceof Window
     return event.originalTarget
-  else 
+  else
     doc = event.originalTarget.ownerDocument or event.originalTarget
     if doc instanceof HTMLDocument or doc instanceof XULDocument
-      return doc.defaultView 
+      return doc.defaultView
 
 getEventRootWindow = (event) ->
   if window = getEventWindow event
     return getRootWindow window
 
-getEventTabBrowser = (event) -> 
+getEventTabBrowser = (event) ->
   cw.gBrowser if cw = getEventRootWindow event
 
 getRootWindow = (window) ->
@@ -59,7 +59,7 @@ getRootWindow = (window) ->
                .QueryInterface(Ci.nsIDocShellTreeItem)
                .rootTreeItem
                .QueryInterface(Ci.nsIInterfaceRequestor)
-               .getInterface(Window); 
+               .getInterface(Window);
 
 isTextInputElement = (element) ->
   return element instanceof HTMLInputElement or \
@@ -97,7 +97,7 @@ loadCss = (name) ->
   if !_sss.sheetRegistered(uri, _sss.AGENT_SHEET)
     _sss.loadAndRegisterSheet(uri, _sss.AGENT_SHEET)
 
-  unload -> 
+  unload ->
     _sss.unregisterSheet(uri, _sss.AGENT_SHEET)
 
 # Simulate mouse click with full chain of event
@@ -138,7 +138,7 @@ writeToClipboard = (window, text) ->
 readFromClipboard = (window) ->
   trans = Cc["@mozilla.org/widget/transferable;1"].createInstance(Ci.nsITransferable);
 
-  if trans.init 
+  if trans.init
     privacyContext = window.QueryInterface(Ci.nsIInterfaceRequestor)
       .getInterface(Ci.nsIWebNavigation)
       .QueryInterface(Ci.nsILoadContext);
@@ -172,7 +172,7 @@ timeIt = (func, msg) ->
 # `blackList`: comma/space separated list of URLs with wildcards (* and !)
 isBlacklisted = (str, blackList) ->
   for rule in blackList.split(/[\s,]+/)
-    rule = rule.replace(/\*/g, '.*').replace(/\!/g, '.') 
+    rule = rule.replace(/\*/g, '.*').replace(/\!/g, '.')
     if str.match new RegExp("^#{ rule }$")
       return true
 
@@ -196,7 +196,7 @@ smoothScroll = (window, dx, dy, msecs) ->
     window.scrollBy dx, dy
   else
     # Callback
-    fn = (_x, _y) -> 
+    fn = (_x, _y) ->
       window.scrollBy(_x, _y)
     # Number of steps
     delta = 10
@@ -233,20 +233,6 @@ browserSearchSubmission = (str) ->
 
   engine = ss.currentEngine or ss.defaultEngine
   return engine.getSubmission(str, null)
-
-# Adds a class the the `element.className` trying to keep the whole class string
-# will formed (without extra spaces at the tails)
-addClass = (element, klass) ->
-  if (element.className?.search klass) == -1
-    if element.className 
-      element.className += " #{ klass }"
-    else
-      element.className = klass 
-
-# Remove a class from the `element.className`
-removeClass = (element, klass) ->
-  name = element.className.replace new RegExp("\\s*#{ klass }"), ""
-  element.className = name or null
 
 # Get hint characters, convert them to lower case and fall back
 # to default hint characters if there are less than 3 chars
@@ -290,6 +276,4 @@ exports.getVersion                = getVersion
 exports.parseHTML                 = parseHTML
 exports.isURL                     = isURL
 exports.browserSearchSubmission   = browserSearchSubmission
-exports.addClass                  = addClass
-exports.removeClass               = removeClass
-exports.getHintChars              = getHintChars 
+exports.getHintChars              = getHintChars


### PR DESCRIPTION
Remove `utils.addClass()` and `utils.removeClass()`. Use
`.classList.add()` and `.classList.remove()` directly on the elements
instead.

My editor is set to strip trailing whitespace, which it did. So a diff of
this commit is a bit messy.
