### PR TITLE
Added missing parenthesis

### DIFF
--- a/extension/packages/commands.coffee
+++ b/extension/packages/commands.coffee
@@ -64,7 +64,7 @@ command_yf = (vim) ->
 command_vf = (vim) ->
   markers = hints.injectHints(vim.window.document)
   if markers?.length > 0
-    vim.enterHintsMode markers, (marker) -> marker.element.focus()
+    vim.enterHintsMode(markers, (marker) -> marker.element.focus())
 
 # Copy current URL to the clipboard
 command_yy = (vim) ->
@@ -361,7 +361,7 @@ hintCharHandler = (vim, keyStr, charCode) ->
     key = regexpEscape(keyStr)
 
     # First do a pre match - count how many markers will match with the new character entered
-    if vim.markers.reduce ((v, marker) -> v or marker.willMatch key), false
+    if vim.markers.reduce(((v, marker) -> v or marker.willMatch(key)), false)
       for marker in vim.markers
         marker.matchHintChar(key)
 

--- a/extension/packages/events.coffee
+++ b/extension/packages/events.coffee
@@ -7,7 +7,7 @@ keyUtils                 = require 'key-utils'
 
 { interfaces: Ci } = Components
 
-vimBucket = new utils.Bucket utils.getWindowId, (obj) -> new Vim obj
+vimBucket = new utils.Bucket(utils.getWindowId, (obj) -> new Vim(obj))
 
 suppressEvent = (event) ->
   event.preventDefault()

--- a/extension/packages/prefs.coffee
+++ b/extension/packages/prefs.coffee
@@ -81,7 +81,7 @@ enableCommand = (key) ->
     while (idx = DISABLED_COMMANDS.indexOf(c)) > -1
       DISABLED_COMMANDS.splice(idx, 1)
 
-  setPref('disabled_commands', JSON.stringify DISABLED_COMMANDS)
+  setPref('disabled_commands', JSON.stringify(DISABLED_COMMANDS))
 
 # Adds command to the disabled list
 disableCommand = (key) ->
@@ -89,7 +89,7 @@ disableCommand = (key) ->
     if DISABLED_COMMANDS.indexOf(c) == -1
       DISABLED_COMMANDS.push(c)
 
-  setPref('disabled_commands', JSON.stringify DISABLED_COMMANDS)
+  setPref('disabled_commands', JSON.stringify(DISABLED_COMMANDS))
 
 # Checks if given command is disabled in the preferences
 isCommandDisabled = (key) ->

--- a/extension/packages/utils.coffee
+++ b/extension/packages/utils.coffee
@@ -186,7 +186,7 @@ getVersion = do ->
     scope = {}
     addonId = getPref('addon_id')
     Cu.import('resource://gre/modules/AddonManager.jsm', scope)
-    scope.AddonManager.getAddonByID addonId, (addon) -> version = addon.version
+    scope.AddonManager.getAddonByID(addonId, (addon) -> version = addon.version)
 
   return ->
     return version


### PR DESCRIPTION
That should be the last of it … until we have decided how to format multiline functions as arguments etc ;)

Note that even functions whose last argument is a one-line function
literal have parenthesis now.

How to do with functions whose last argument is a multi-line function is
not settled yet. Neither is whether `require` should have parenthesis.
