### PR TITLE
Closes #168 -- for real this time

### DIFF
--- a/extension/packages/utils.coffee
+++ b/extension/packages/utils.coffee
@@ -96,11 +96,14 @@ loadCss = do ->
   sss = Cc['@mozilla.org/content/style-sheet-service;1'].getService(Ci.nsIStyleSheetService)
   return (name) ->
     uri = cssUri(name)
-    if !sss.sheetRegistered(uri, sss.AUTHOR_SHEET)
-      sss.loadAndRegisterSheet(uri, sss.AUTHOR_SHEET)
+    # `AGENT_SHEET` is used to override userContent.css and Stylish. Custom website themes installed
+    # by users often make the hint markers unreadable, for example. Just using `!important` in the
+    # CSS is not enough.
+    if !sss.sheetRegistered(uri, sss.AGENT_SHEET)
+      sss.loadAndRegisterSheet(uri, sss.AGENT_SHEET)
 
     unload ->
-      sss.unregisterSheet(uri, sss.AUTHOR_SHEET)
+      sss.unregisterSheet(uri, sss.AGENT_SHEET)
 
 # Simulate mouse click with full chain of event
 # Copied from Vimium codebase


### PR DESCRIPTION
Commit bc315d9 made changes to the CSS of VimFx:
1. It changed from "agent" sheets to "author" sheets
2. It removed all `!important`

That caused problems with userstyles in userContent.css or Stylish.
Website themes installed by the user often make the hint markers
unreadable, for example.

Commit 21a09a1 reverted # 2.

After a while, though, I noticed that it wasn't enough, unfortunately.

This commit reverts # 1, and adds a comment about it.
