### PR TITLE
Fix #192: Clarify help customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ VimFx will be nice to your browser and to your habits. Promise.
 
 - Concise shortcuts for most commonly performed actions
 - Follow and access controls on the page using hint markers
-- Easy access to the Help page which describes all available shortcuts (press ?)
+- Easy access to the keyboard shortcuts dialog, which describes and lets you customize all available shortcuts (press ?)
 
 ## Shortcuts
 
-Might not be up to date. Please refer to the Help dialog withing the extension
-for the most relevant list.
+This is a text representation of the keyboard shortcuts dialog within the extension. Might not be up to date.
+Press ? or use the toolbar button to open the dialog, which helps you remember the shortcuts, and lets you customize them.
 
-Global shortcut to enable/disable VimFx: `Shift-Alt-v`
+Global shortcut to enable/disable VimFx: `shift-alt-v`
 
 ### Dealing with URLs
 
@@ -106,9 +106,11 @@ Global shortcut to enable/disable VimFx: `Shift-Alt-v`
     a.,a/   Enter Find mode to highlight all matches
     n       Go to the next Find match
     N       Go to the previous Find match
-    ?,>     Show Help Dialog
+    ?,>     Show this dialog
     Esc     Close this dialog and cancel hint markers
     :       Open Developer Toolbar
+
+Can't see a link hint, because it's overlapped by another? Try pressing space or shift-space!
 
 ## Contributing and Reporting Issues
 
@@ -128,7 +130,7 @@ Global shortcut to enable/disable VimFx: `Shift-Alt-v`
 - Put a file called exactly `VimFx@akhodakivskiy.github.com` in the extensions/ folder of a Firefox
   profile, containing the absolute path to the extension/ folder in the project. Then you just need
   to restart Firefox (use some add-on!) after each change. More details in [this MDN article][mdn-extdevenv].
-- Only create tickets for issues and feature requests in English. Otherwise duplicate 
+- Only create tickets for issues and feature requests in English. Otherwise duplicate
   tickets in different languages will pile up.
 
 [mdn-extdevenv]: https://developer.mozilla.org/en-US/docs/Setting_up_extension_development_environment#Firefox_extension_proxy_file

--- a/extension/locale/de/options.dtd
+++ b/extension/locale/de/options.dtd
@@ -15,3 +15,6 @@
 
 <!ENTITY pref.hints_bloom_on.title "Intelligente Hinweiszuweisung">
 <!ENTITY pref.hints_bloom_on.desc  "Oft besuchten Links kürzere Hinweise zuweisen">
+
+<!ENTITY customizeButton.title "Keyboard Shortcuts">
+<!ENTITY customizeButton.label "Customize">

--- a/extension/locale/de/vimfx.properties
+++ b/extension/locale/de/vimfx.properties
@@ -1,8 +1,7 @@
-button_tooltip_enabled=VimFx ist aktiviert. Zum Deaktivieren hier klicken. (Shift+Alt+V)
-button_tooltip_disabled=VimFx ist deaktiviert. Zum Aktivieren hier klicken. (Shift+Alt+V)
+button_tooltip_enabled=VimFx ist aktiviert. Zum Deaktivieren hier klicken. (shift-alt-v)
+button_tooltip_disabled=VimFx ist deaktiviert. Zum Aktivieren hier klicken. (shift-alt-v)
 button_tooltip_blacklisted=Diese Seite ist auf der schwarzen Liste
 item_preferences=Einstellungen
-item_help=Hilfe
 item_blacklist_button_tooltip=Schwarze Liste
 
 help_section_urls=Umgang mit URLs
@@ -51,7 +50,7 @@ help_command_back=Eine Seite zurück in der Chronik
 help_command_forward=Eine Seite vorwärts in der Chronik
 
 help_section_misc=Verschiedenes
-help_command_help=Hilfe anzeigen
+help_command_help=Show this dialog
 help_command_Esc=Dialog schließen oder Hinweise ausblenden
 help_command_find=Suchmodus aktivieren
 help_command_find_hl=Suchmodus aktivieren und alle Übereinstimmungen markieren
@@ -59,7 +58,7 @@ help_command_find_next=Zur nächsten Übereinstimmung springen
 help_command_find_prev=Zur vorherigen Übereinstimmung springen
 help_command_dev=Entwickler-Werkzeuge öffnen
 
-help=Hilfe
+help_title=Keyboard Shortcuts
 help_version=Version
 
 help_overlapping_hints=Can't see a link hint, because it's overlapped by another? Try pressing space or shift-space!

--- a/extension/locale/el-GR/options.dtd
+++ b/extension/locale/el-GR/options.dtd
@@ -16,3 +16,6 @@ Wildcards allowed: *, !. Προεπιλογή: *mail.google.com*">
 
 <!ENTITY pref.hints_bloom_on.title "Έξυπνη ανάθεση υποδείξεων">
 <!ENTITY pref.hints_bloom_on.desc  "Ανάθεσε μικρότερες υποδείξεις στους συνδέσμους που οι χρήστες επισκέπτονται συχνότερα">
+
+<!ENTITY customizeButton.title "Keyboard Shortcuts">
+<!ENTITY customizeButton.label "Customize">

--- a/extension/locale/el-GR/vimfx.properties
+++ b/extension/locale/el-GR/vimfx.properties
@@ -1,8 +1,7 @@
-button_tooltip_enabled=Το VimFx είναι ενεργοποιημένο. Κάντε κλικ για να το απενεργοποιήσετε (Shift+Alt+V)
-button_tooltip_disabled=Το VimFx είναι απενεργοποιημένο. Κάντε κλικ για να το ενεργοποιήσετε (Shift+Alt+V)
+button_tooltip_enabled=Το VimFx είναι ενεργοποιημένο. Κάντε κλικ για να το απενεργοποιήσετε (shift-alt-v)
+button_tooltip_disabled=Το VimFx είναι απενεργοποιημένο. Κάντε κλικ για να το ενεργοποιήσετε (shift-alt-v)
 button_tooltip_blacklisted=Το VimFx είναι στην μαύρη λίστα σε αυτήν την σελίδα.
 item_preferences=Προτιμήσεις
-item_help=Βοήθεια
 item_blacklist_button_tooltip=Μαύρη Λίστα
 
 help_section_urls=Όσον αφορά τις διευθύνσεις
@@ -52,7 +51,7 @@ help_command_back=Πήγαινε πίσω στο ιστορικό
 help_command_forward=Πήγαινε μπροστά στο ιστορικό
 
 help_section_misc=Διάφορα
-help_command_help=Άνοιγμα Βοήθειας
+help_command_help=Show this dialog
 help_command_Esc=Κλείσε αυτό το παράθυρο διαλόγου και ακύρωσε τους δείκτες
 help_command_find=Είσοδος σε λειτουργία Εύρεσης (Find mode)
 help_command_find_hl=Είσοδος σε λειτουργία Εύρεσης (Find mode) επισημαίνοντας όλες τις αντιστοιχίες
@@ -60,7 +59,7 @@ help_command_find_next=Πήγαινε στην επόμενη ατιστοιχί
 help_command_find_prev=Πήγαινε στην προηγούμενη αντιστοιχία
 help_command_dev=Άνοιγμα Developer Toolbar
 
-help=Βοήθεια
+help_title=Keyboard Shortcuts
 help_version=Έκδοση
 
 help_overlapping_hints=Can't see a link hint, because it's overlapped by another? Try pressing space or shift-space!

--- a/extension/locale/en-US/options.dtd
+++ b/extension/locale/en-US/options.dtd
@@ -17,3 +17,5 @@ Wildcards allowed: *, !. Default: *mail.google.com*">
 <!ENTITY pref.hints_bloom_on.title "Smart hint assignment">
 <!ENTITY pref.hints_bloom_on.desc  "Assign shorter hints to the links that users visit most often">
 
+<!ENTITY customizeButton.title "Keyboard Shortcuts">
+<!ENTITY customizeButton.label "Customize">

--- a/extension/locale/en-US/vimfx.properties
+++ b/extension/locale/en-US/vimfx.properties
@@ -1,8 +1,7 @@
-button_tooltip_enabled=VimFx is Enabled. Click to Disable (Shift+Alt+V)
-button_tooltip_disabled=VimFx is Disabled. Click to Enable (Shift+Alt+V)
+button_tooltip_enabled=VimFx is Enabled. Click to Disable (shift-alt-v)
+button_tooltip_disabled=VimFx is Disabled. Click to Enable (shift-alt-v)
 button_tooltip_blacklisted=VimFx is Blacklisted on this Page
 item_preferences=Preferences
-item_help=Help
 item_blacklist_button_tooltip=Blacklist
 
 help_section_urls=Dealing with URLs
@@ -52,7 +51,7 @@ help_command_back=Go Back in history
 help_command_forward=Go Forward in history
 
 help_section_misc=Misc
-help_command_help=Show Help Dialog
+help_command_help=Show this dialog
 help_command_Esc=Close this dialog and cancel hint markers
 help_command_find=Enter Find mode
 help_command_find_hl=Enter Find mode highlighting all matches
@@ -60,7 +59,7 @@ help_command_find_next=Go to the next Find match
 help_command_find_prev=Go to the previous Find match
 help_command_dev=Open Developer Toolbar
 
-help=Help
+help_title=Keyboard Shortcuts
 help_version=Version
 
 help_overlapping_hints=Can't see a link hint, because it's overlapped by another? Try pressing space or shift-space!

--- a/extension/locale/hu/options.dtd
+++ b/extension/locale/hu/options.dtd
@@ -15,3 +15,6 @@
 
 <!ENTITY pref.hints_bloom_on.title "Smart hint assignment (needs translation)">
 <!ENTITY pref.hints_bloom_on.desc  "Assign shorter hints to the links that users visit most often (needs translation)">
+
+<!ENTITY customizeButton.title "Keyboard Shortcuts">
+<!ENTITY customizeButton.label "Customize">

--- a/extension/locale/hu/vimfx.properties
+++ b/extension/locale/hu/vimfx.properties
@@ -1,8 +1,7 @@
-button_tooltip_enabled=VimFx aktív. Kattints az inaktiváláshoz (Shift+Alt+V)
-button_tooltip_disabled=VimFx inaktív. Kattints az aktiváláshoz (Shift+Alt+V)
+button_tooltip_enabled=VimFx aktív. Kattints az inaktiváláshoz (shift-alt-v)
+button_tooltip_disabled=VimFx inaktív. Kattints az aktiváláshoz (shift-alt-v)
 button_tooltip_blacklisted=Az oldal feketelistázva a VimFX-ben.
 item_preferences=Beállítások
-item_help=Súgó
 item_blacklist_button_tooltip=Feketelista
 
 help_section_urls=URL műveletek
@@ -51,7 +50,7 @@ help_command_back=Vissza az előzményekben
 help_command_forward=Előre az előzményekben
 
 help_section_misc=Általános
-help_command_help=Súgó megjelenítése
+help_command_help=Show this dialog
 help_command_Esc=Ennek az ablaknak bezárása és segédletek elrejtése
 help_command_find=Keresési módba lépés
 help_command_find_hl=Enter Find mode highlighting all matches (needs translation)
@@ -59,7 +58,7 @@ help_command_find_next=Következő találatra ugrás
 help_command_find_prev=Előző találatra ugrás
 help_command_dev=Open Developer Toolbar(needs translation)
 
-help=Segítség
+help_title=Keyboard Shortcuts
 help_version=Verzió
 
 help_overlapping_hints=Can't see a link hint, because it's overlapped by another? Try pressing space or shift-space!

--- a/extension/locale/id/options.dtd
+++ b/extension/locale/id/options.dtd
@@ -17,3 +17,5 @@ Wildcard dibolehkan: *, !. Default: *mail.google.com*">
 <!ENTITY pref.hints_bloom_on.title "Penempatan petunjuk cerdas">
 <!ENTITY pref.hints_bloom_on.desc  "Menempatkan petunjuk lebih pendek untuk pranala yang sering dikunjungi">
 
+<!ENTITY customizeButton.title "Keyboard Shortcuts">
+<!ENTITY customizeButton.label "Customize">

--- a/extension/locale/id/vimfx.properties
+++ b/extension/locale/id/vimfx.properties
@@ -1,8 +1,7 @@
-button_tooltip_enabled=VimFx telah Aktif. Klik untuk Nonaktifkan (Shift+Alt+V)
-button_tooltip_disabled=VimFx telah Nonaktif. Klik untuk Aktifkan (Shift+Alt+V)
+button_tooltip_enabled=VimFx telah Aktif. Klik untuk Nonaktifkan (shift-alt-v)
+button_tooltip_disabled=VimFx telah Nonaktif. Klik untuk Aktifkan (shift-alt-v)
 button_tooltip_blacklisted=VimFx telah Dilarang pada halaman ini
 item_preferences=Preferensi
-item_help=Bantuan
 item_blacklist_button_tooltip=Larangan
 
 help_section_urls=Penanganan URL
@@ -51,7 +50,7 @@ help_command_back=Mundur dalam history
 help_command_forward=Maju dalam history
 
 help_section_misc=Lain-lain
-help_command_help=Tampilkan Dialog Bantuan
+help_command_help=Show this dialog
 help_command_Esc=tutup dialog ini dan batalkan penanda bantuan
 help_command_find=Masuk mode pencarian
 help_command_find_hl=Masuk mode pencarian menandai semua cocok
@@ -59,7 +58,7 @@ help_command_find_next=Menuju temuan cocok setelah
 help_command_find_prev=Menuju temuan cocok sebelum
 help_command_dev=Buka Toolbar Pengembang
 
-help=Bantuan
+help_title=Keyboard Shortcuts
 help_version=Versi
 
 help_overlapping_hints=Can't see a link hint, because it's overlapped by another? Try pressing space or shift-space!

--- a/extension/locale/nl/options.dtd
+++ b/extension/locale/nl/options.dtd
@@ -16,3 +16,6 @@ Speciale tekens toegestaan: *, !. Standaard: *mail.google.com*">
 
 <!ENTITY pref.hints_bloom_on.title "Smart hint assignment (needs translation)">
 <!ENTITY pref.hints_bloom_on.desc  "Assign shorter hints to the links that users visit most often (needs translation)">
+
+<!ENTITY customizeButton.title "Keyboard Shortcuts">
+<!ENTITY customizeButton.label "Customize">

--- a/extension/locale/nl/vimfx.properties
+++ b/extension/locale/nl/vimfx.properties
@@ -1,8 +1,7 @@
-button_tooltip_enabled=VimFx is ingeschakeld. Klik om uit te schakelen (Shift-Alt-V)
-button_tooltip_disabled=VimFx is uitgeschakeld. Klik om in te schakelen (Shift-Alt-V)
+button_tooltip_enabled=VimFx is ingeschakeld. Klik om uit te schakelen (shift-alt-v)
+button_tooltip_disabled=VimFx is uitgeschakeld. Klik om in te schakelen (shift-alt-v)
 button_tooltip_blacklisted=VimFx is uitgeschakeld op deze pagina
 item_preferences=Instellingen
-item_help=Help
 item_blacklist_button_tooltip=Zwarte lijst
 
 help_section_urls=Omgaan met URLs
@@ -52,7 +51,7 @@ help_command_back=Ga terug in de geschiedenis
 help_command_forward=Ga vooruit in geschiedenis
 
 help_section_misc=Trivia
-help_command_help=Toon help
+help_command_help=Show this dialog
 help_command_Esc=Sluit dit venster of verwijder linkmarkeringen
 help_command_find=Zoeken
 help_command_find_hl=Zoek met highlights
@@ -60,7 +59,7 @@ help_command_find_next=Ga naar volgende overeenkomst
 help_command_find_prev=Ga naar vorige overeenkomst
 help_command_dev=Open ontwikkelaarswerkbalk
 
-help=Help
+help_title=Keyboard Shortcuts
 help_version=Versie
 
 help_overlapping_hints=Can't see a link hint, because it's overlapped by another? Try pressing space or shift-space!

--- a/extension/locale/pl/options.dtd
+++ b/extension/locale/pl/options.dtd
@@ -16,3 +16,6 @@ Dopuszczalne wieloznaczniki: *, !. Domyślnie: *mail.google.com*">
 
 <!ENTITY pref.hints_bloom_on.title "Smart hint assignment">
 <!ENTITY pref.hints_bloom_on.desc  "Assign shorter hints to the links that users visit most often">
+
+<!ENTITY customizeButton.title "Keyboard Shortcuts">
+<!ENTITY customizeButton.label "Customize">

--- a/extension/locale/pl/vimfx.properties
+++ b/extension/locale/pl/vimfx.properties
@@ -1,8 +1,7 @@
-button_tooltip_enabled=VimFx jest włączony. Kliknij, aby wyłączyć (Shift+Alt+V)
-button_tooltip_disabled=VimFx jest wyłączony. Kliknij, aby włączyć (Shift+Alt+V)
+button_tooltip_enabled=VimFx jest włączony. Kliknij, aby wyłączyć (shift-alt-v)
+button_tooltip_disabled=VimFx jest wyłączony. Kliknij, aby włączyć (shift-alt-v)
 button_tooltip_blacklisted=Ta strona jest na czarnej liście VimFx
 item_preferences=Preferencje
-item_help=Pomoc
 item_blacklist_button_tooltip=Czarna lista
 
 help_section_urls=Praca z adresami
@@ -52,7 +51,7 @@ help_command_back=Wstecz
 help_command_forward=Dalej
 
 help_section_misc=Różne
-help_command_help=Wyświetl okno pomocy
+help_command_help=Show this dialog
 help_command_Esc=Zamknij to okno / ukryj podpowiedzi przy linkach
 help_command_find=Znajdź
 help_command_find_hl=Znajdź i podkreśl wszystkie wystąpienia
@@ -60,7 +59,7 @@ help_command_find_next=Znajdź następne
 help_command_find_prev=Znajdź poprzednie
 help_command_dev=Otwórz pasek programisty
 
-help=Pomoc
+help_title=Keyboard Shortcuts
 help_version=Wersja
 
 help_overlapping_hints=Can't see a link hint, because it's overlapped by another? Try pressing space or shift-space!

--- a/extension/locale/ru/options.dtd
+++ b/extension/locale/ru/options.dtd
@@ -16,3 +16,6 @@
 
 <!ENTITY pref.hints_bloom_on.title "Умное распределение маркеров">
 <!ENTITY pref.hints_bloom_on.desc  "Назначать короткие маркеры ссылкам и элементам, которые часто используются">
+
+<!ENTITY customizeButton.title "Keyboard Shortcuts">
+<!ENTITY customizeButton.label "Customize">

--- a/extension/locale/ru/vimfx.properties
+++ b/extension/locale/ru/vimfx.properties
@@ -1,8 +1,7 @@
-button_tooltip_enabled=VimFx работает. Нажмите чтобы выключить (Shift+Alt+V)
-button_tooltip_disabled=VimFx не работает. Нажмите чтобы включить (Shift+Alt+V)
+button_tooltip_enabled=VimFx работает. Нажмите чтобы выключить (shift-alt-v)
+button_tooltip_disabled=VimFx не работает. Нажмите чтобы включить (shift-alt-v)
 button_tooltip_blacklisted=VimFx содержит текущую страницу в стоп-списке
 item_preferences=Настройки
-item_help=Справка
 item_blacklist_button_tooltip=Добавить в стоп-список
 
 help_section_urls=Адресная Строка
@@ -52,7 +51,7 @@ help_command_back=Предыдущая страница
 help_command_forward=Следующая страница
 
 help_section_misc=Разное
-help_command_help=Показать справку
+help_command_help=Show this dialog
 help_command_Esc=Закрыть справку, поиск или отменить действие с маркерами
 help_command_find=Режим поиска
 help_command_find_hl=Режим поиска с выделением всех совпадений
@@ -60,7 +59,7 @@ help_command_find_next=Перейти к следующему результат
 help_command_find_prev=Перейти к предыдущему результату поиска
 help_command_dev=Открыть Панель Разработки
 
-help=Справка
+help_title=Keyboard Shortcuts
 help_version=Версия
 
 help_enjoying=Расширение понравилось?

--- a/extension/locale/zh-CN/options.dtd
+++ b/extension/locale/zh-CN/options.dtd
@@ -16,3 +16,6 @@
 
 <!ENTITY pref.hints_bloom_on.title "智能分配提示符">
 <!ENTITY pref.hints_bloom_on.desc  "为最常访问的链接分配更短的提示符">
+
+<!ENTITY customizeButton.title "Keyboard Shortcuts">
+<!ENTITY customizeButton.label "Customize">

--- a/extension/locale/zh-CN/vimfx.properties
+++ b/extension/locale/zh-CN/vimfx.properties
@@ -1,8 +1,7 @@
-button_tooltip_enabled=VimFx 已启用。点击禁用 (Shift+Alt+V)
-button_tooltip_disabled=VimFx 已禁用。点击启用 (Shift+Alt+V)
+button_tooltip_enabled=VimFx 已启用。点击禁用 (shift-alt-v)
+button_tooltip_disabled=VimFx 已禁用。点击启用 (shift-alt-v)
 button_tooltip_blacklisted=当前页面已被列入黑名单
 item_preferences=首选项
-item_help=帮助
 item_blacklist_button_tooltip=添加到黑名单
 
 help_section_urls=处理 URL
@@ -52,7 +51,7 @@ help_command_back=后退
 help_command_forward=前进
 
 help_section_misc=杂项
-help_command_help=显示帮助对话框
+help_command_help=Show this dialog
 help_command_Esc=关闭此对话框及取消提示（hint）标记
 help_command_find=进入查找模式
 help_command_find_hl=进入查找模式并高亮所有匹配项
@@ -60,7 +59,7 @@ help_command_find_next=跳到下一个查找匹配项
 help_command_find_prev=跳到上一个查找匹配项
 help_command_dev=打开开发者工具栏
 
-help=帮助
+help_title=Keyboard Shortcuts
 help_version=版本
 
 help_overlapping_hints=Can't see a link hint, because it's overlapped by another? Try pressing space ro shift-space!

--- a/extension/options.xul
+++ b/extension/options.xul
@@ -3,16 +3,19 @@
 <!DOCTYPE mydialog SYSTEM "chrome://vimfx/locale/options.dtd">
 
 <vbox xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-    <setting pref="extensions.VimFx.hint_chars" type="string" 
+    <setting pref="extensions.VimFx.hint_chars" type="string"
         title="&pref.hint_chars.title;" desc="&pref.hint_chars.desc;" />
-    <setting pref="extensions.VimFx.black_list" type="string" 
+    <setting pref="extensions.VimFx.black_list" type="string"
         title="&pref.black_list.title;" desc="&pref.black_list.desc;" />
-    <setting pref="extensions.VimFx.blur_on_esc" type="bool" 
+    <setting pref="extensions.VimFx.blur_on_esc" type="bool"
         title="&pref.blur_on_esc.title;" desc="&pref.blur_on_esc.desc;" />
-    <setting pref="extensions.VimFx.leave_dt_on_esc" type="bool" 
+    <setting pref="extensions.VimFx.leave_dt_on_esc" type="bool"
         title="&pref.leave_dt_on_esc.title;" desc="&pref.leave_dt_on_esc.desc;" />
-    <setting pref="extensions.VimFx.scroll_step_lines" type="integer" 
+    <setting pref="extensions.VimFx.scroll_step_lines" type="integer"
         title="&pref.scroll_step_lines.title;" desc="&pref.scroll_step_lines.desc;" />
-    <setting pref="extensions.VimFx.hints_bloom_on" type="bool" 
+    <setting pref="extensions.VimFx.hints_bloom_on" type="bool"
         title="&pref.hints_bloom_on.title;" desc="&pref.hints_bloom_on.desc;" />
+    <setting title="&customizeButton.title;" type="control">
+        <button id="customizeButton" label="&customizeButton.label;" />
+    </setting>
 </vbox>

--- a/extension/packages/button.coffee
+++ b/extension/packages/button.coffee
@@ -91,7 +91,7 @@ createMenupopup = (window) ->
 
   itemHelp = doc.createElement('menuitem')
   itemHelp.id = MENU_ITEM_HELP
-  itemHelp.setAttribute('label', _('item_help'))
+  itemHelp.setAttribute('label', _('help_title'))
 
   menupopup = doc.createElement('menupopup')
   menupopup.id = MENUPOPUP_ID

--- a/extension/packages/help.coffee
+++ b/extension/packages/help.coffee
@@ -1,26 +1,32 @@
-utils = require 'utils'
-prefs = require 'prefs'
-{ _ } = require 'l10n'
+utils        = require 'utils'
+prefs        = require 'prefs'
+{ _ }        = require 'l10n'
 
 { classes: Cc, interfaces: Ci, utils: Cu } = Components
+
+XULDocument  = Ci.nsIDOMXULDocument
 
 CONTAINER_ID = 'VimFxHelpDialogContainer'
 
 removeHelp = (document) ->
-  if div = document.getElementById(CONTAINER_ID)
-    div.parentNode.removeChild(div)
+  document.getElementById(CONTAINER_ID)?.remove()
 
 injectHelp = (document, commands) ->
   if document.documentElement
-    if div = document.getElementById(CONTAINER_ID)
-      div.parentNode.removeChild(div)
-    div = document.createElement 'div'
-    div.id = CONTAINER_ID
-    div.className = 'VimFxReset'
+    removeHelp(document)
 
-    div.appendChild(utils.parseHTML(document, helpDialogHtml(commands)))
+    if document instanceof XULDocument
+      container = document.createElement('box')
+      # The `.VimFxReset` class is not needed in XUL documents. Instead it actullay causes layout
+      # problems there!
+    else
+      container = document.createElement('div')
+      container.className = 'VimFxReset'
+    container.id = CONTAINER_ID
 
-    document.documentElement.appendChild(div)
+    container.appendChild(utils.parseHTML(document, helpDialogHtml(commands)))
+
+    document.documentElement.appendChild(container)
 
     installHandlers(document, commands)
 
@@ -133,7 +139,7 @@ helpDialogHtml = (commands) ->
     <div class="VimFxReset VimFxHeader">
       <div class="VimFxReset VimFxTitle">
         <span class="VimFxReset VimFxTitleVim">Vim</span><span class="VimFxReset VimFxTitleFx">Fx</span>
-        <span class="VimFxReset">#{ _('help') }</span>
+        <span class="VimFxReset">#{ _('help_title') }</span>
       </div>
       <span class="VimFxReset VimFxVersion">#{ _('help_version') } #{ utils.getVersion() }</span>
       <a class="VimFxReset VimFxClose" id="VimFxClose" href="#">&#10006;</a>

--- a/extension/packages/hints.coffee
+++ b/extension/packages/hints.coffee
@@ -5,9 +5,9 @@ utils                     = require 'utils'
 
 { interfaces: Ci } = Components
 
-HTMLDocument      = Ci.nsIDOMHTMLDocument
-XULDocument       = Ci.nsIDOMXULDocument
-XPathResult       = Ci.nsIDOMXPathResult
+HTMLDocument = Ci.nsIDOMHTMLDocument
+XULDocument  = Ci.nsIDOMXULDocument
+XPathResult  = Ci.nsIDOMXPathResult
 
 CONTAINER_ID = 'VimFxHintMarkerContainer'
 

--- a/extension/packages/options.coffee
+++ b/extension/packages/options.coffee
@@ -1,16 +1,25 @@
 { removeDuplicateCharacters } = require 'utils'
-{ unload }  = require 'unload'
-{ getPref } = require 'prefs'
+{ unload }   = require 'unload'
+{ getPref }  = require 'prefs'
+help         = require 'help'
+{ commands } = require 'commands'
 
 observer =
   observe: (document, topic, addon) ->
     return unless addon == getPref('addon_id')
+
     hintCharsInput = document.querySelector('setting[pref="extensions.VimFx.hint_chars"]')
+
+    customizeButton = document.getElementById('customizeButton')
+    injectHelp = help.injectHelp.bind(undefined, document, commands)
+
     switch topic
       when 'addon-options-displayed'
         hintCharsInput.addEventListener('change', filterChars, false)
+        customizeButton.addEventListener('command', injectHelp, false)
       when 'addon-options-hidden'
         hintCharsInput.removeEventListener('change', filterChars, false)
+        customizeButton.removeEventListener('command', injectHelp, false)
 
 filterChars = (event) ->
   input = event.target


### PR DESCRIPTION
- Add button in settings page to customize keyboard shortcuts (open the
  help dialog)
- Change "Help" to "Keyboard shortcuts"
- Fix bug: Help dialog broke the layout in XUL pages
