### PR TITLE
Fix #213: Suppress logic bug

### DIFF
--- a/extension/packages/events.coffee
+++ b/extension/packages/events.coffee
@@ -29,26 +29,10 @@ checkPassthrough = (event) ->
       when 'popuphidden' then false
 
 suppress = false
-keyListener = (event) ->
-  try
-    return if passthrough or getPref('disabled')
-    return unless window = utils.getEventCurrentTabWindow(event)
-    return unless vim = vimBucket.get(window)
-    return if vim.blacklisted
-
-    if event.type == 'keydown'
-      suppress = false
-
-      return unless keyStr = keyStrFromEvent(event)
-
-      suppress = vim.onInput(keyStr, event)
-
-    if suppress
-      event.preventDefault()
-      event.stopPropagation()
-
-  catch error
-    console.log("#{ error } (in #{ event.type })\n#{ error.stack.replace(/@.+-> /g, '@') }")
+suppressEvent = (event) ->
+  if suppress
+    event.preventDefault()
+    event.stopPropagation()
 
 removeVimFromTab = (tab, gBrowser) ->
   return unless browser = gBrowser.getBrowserForTab(tab)
@@ -60,9 +44,35 @@ updateButton = (vim) ->
 
 # The following listeners are installed on every top level Chrome window
 windowsListeners =
-  keydown:     keyListener
-  keypress:    keyListener
-  keyup:       keyListener
+  keydown: (event) ->
+    try
+      # No matter what, always reset the `suppress` flag, so we don't suppress more than intended.
+      suppress = false
+
+      return if passthrough or getPref('disabled')
+
+      return unless window = utils.getEventCurrentTabWindow(event)
+      return unless vim = vimBucket.get(window)
+
+      return if vim.blacklisted
+
+      return unless keyStr = keyStrFromEvent(event)
+      suppress = vim.onInput(keyStr, event)
+
+      suppressEvent(event)
+
+    catch error
+      console.error("#{ error }\n#{ error.stack.replace(/@.+-> /g, '@') }")
+
+  # Note that the below event listeners can suppress the event even in blacklisted sites. That's
+  # intentional. For example, if you press 'x' to close the current tab, it will close before keyup
+  # fires. So keyup (and perhaps keypress) will fire in another tab. Even if that particular tab is
+  # blacklisted, we must suppress the event, so that 'x' isn't sent to the page. The rule is simple:
+  # If the `suppress` flag is `true`, the event should be suppressed, no matter what. It has the
+  # highest priority.
+  keypress: suppressEvent
+  keyup:    suppressEvent
+
   popupshown:  checkPassthrough
   popuphidden: checkPassthrough
 


### PR DESCRIPTION
For example, if you press 'x' to close the current tab, it will close
before keyup fires. So keyup (and perhaps keypress) will fire in another
tab. Even if that particular tab is blacklisted, we must suppress the
event, so that 'x' isn't sent to the page. The rule is simple: If the
`suppress` flag is `true`, the event should be suppressed, no matter what.
It has the highest priority.

Previously, `vim.blacklisted` checks were performed even in keypress and
keyup, which caused the suppress to be ignored.
