### PR TITLE
Add arrow keys to key-utils.coffee

### DIFF
--- a/extension/packages/key-utils.coffee
+++ b/extension/packages/key-utils.coffee
@@ -24,6 +24,10 @@ keyCharFromCode = (keyCode, shiftKey = false) ->
       [ KE.DOM_VK_SPACE,          KE.DOM_VK_SPACE,      'Space',     'Shift-Space'      ],
       [ KE.DOM_VK_TAB,            KE.DOM_VK_TAB,        'Tab',       'Shift-Tab'        ],
       [ KE.DOM_VK_RETURN,         KE.DOM_VK_RETURN,     'Return',    'Shift-Return'     ],
+      [ KE.DOM_VK_LEFT,           KE.DOM_VK_LEFT,       'Left',      'Shift-Left'       ],
+      [ KE.DOM_VK_RIGHT,          KE.DOM_VK_RIGHT,      'Right',     'Shift-Right'      ],
+      [ KE.DOM_VK_UP,             KE.DOM_VK_UP,         'Up',        'Shift-Up'         ],
+      [ KE.DOM_VK_DOWN,           KE.DOM_VK_DOWN,       'Down',      'Shift-Down'       ],
 
       [ KE.DOM_VK_1,              KE.DOM_VK_EXCLAMATION,          '1',  '!' ],
       [ KE.DOM_VK_2,              KE.DOM_VK_AT,                   '2',  '@' ],


### PR DESCRIPTION
This patch allows for arrow-keys to be bound, if users wishes to configure such key bindings. While strictly speaking arrow keys is not very vim-style, VimFx provides an excellent keyboard shortcut system, and it's only natural to use it.
