### PR TITLE
Fix #233: Allow hint chars to be case sensitive

### DIFF
--- a/extension/locale/de/options.dtd
+++ b/extension/locale/de/options.dtd
@@ -1,11 +1,14 @@
-<!ENTITY pref.hint_chars.title      "Zeichen für Hinweise">
-<!ENTITY pref.hint_chars.desc       "Voreinstellung: fjdkslaghrueiwovncm">
+<!ENTITY pref.hint_chars.title "Zeichen für Hinweise">
+<!ENTITY pref.hint_chars.desc  "Voreinstellung: FJDKSLAGHRUEIWOVNCM">
 
-<!ENTITY pref.black_list.title      "Schwarze Liste">
-<!ENTITY pref.black_list.desc       "Durch Komma getrennte Liste von URLs für die VimFx automatisch deaktiviert werden soll. Erlaubte Wildcard-Zeichen: *, !. Voreinstellung: *mail.google.com*">
+<!ENTITY pref.hint_chars_ignore_case.title "Hint Chars Ignore Case">
+<!ENTITY pref.hint_chars_ignore_case.desc  "Treat lowercase and uppercase letters as the same char">
 
-<!ENTITY pref.scroll_step_lines.title     "Scroll-Schrittweite">
-<!ENTITY pref.scroll_step_lines.desc      "Scroll-Schrittweite">
+<!ENTITY pref.black_list.title "Schwarze Liste">
+<!ENTITY pref.black_list.desc  "Durch Komma getrennte Liste von URLs für die VimFx automatisch deaktiviert werden soll. Erlaubte Wildcard-Zeichen: *, !. Voreinstellung: *mail.google.com*">
+
+<!ENTITY pref.scroll_step_lines.title "Scroll-Schrittweite">
+<!ENTITY pref.scroll_step_lines.desc  "Scroll-Schrittweite">
 
 <!ENTITY pref.hints_bloom_on.title "Intelligente Hinweiszuweisung">
 <!ENTITY pref.hints_bloom_on.desc  "Oft besuchten Links kürzere Hinweise zuweisen">

--- a/extension/locale/el-GR/options.dtd
+++ b/extension/locale/el-GR/options.dtd
@@ -1,8 +1,11 @@
-<!ENTITY pref.hint_chars.title      "Χαρακτήρες Δεικτών">
-<!ENTITY pref.hint_chars.desc       "Προεπιλογή: fjdkslaghrueiwovncm">
+<!ENTITY pref.hint_chars.title "Χαρακτήρες Δεικτών">
+<!ENTITY pref.hint_chars.desc  "Προεπιλογή: FJDKSLAGHRUEIWOVNCM">
 
-<!ENTITY pref.black_list.title      "Μαύρη Λίστα">
-<!ENTITY pref.black_list.desc       "Διευθύνσης διαχωρισμένες με κόμματα στις οποίες το VimFX θα είναι αυτόματα απενεργοποιημένο.
+<!ENTITY pref.hint_chars_ignore_case.title "Hint Chars Ignore Case">
+<!ENTITY pref.hint_chars_ignore_case.desc  "Treat lowercase and uppercase letters as the same char">
+
+<!ENTITY pref.black_list.title "Μαύρη Λίστα">
+<!ENTITY pref.black_list.desc  "Διευθύνσης διαχωρισμένες με κόμματα στις οποίες το VimFX θα είναι αυτόματα απενεργοποιημένο.
 Επιτρέπονται χαρακτήρες μπαλαντέρ: *, !. Προεπιλογή: *mail.google.com*">
 
 <!ENTITY pref.scroll_step_lines.title "Βήμα Κύλισης">

--- a/extension/locale/en-US/options.dtd
+++ b/extension/locale/en-US/options.dtd
@@ -1,8 +1,11 @@
-<!ENTITY pref.hint_chars.title      "Hint Chars">
-<!ENTITY pref.hint_chars.desc       "Default: fjdkslaghrueiwovncm">
+<!ENTITY pref.hint_chars.title "Hint Chars">
+<!ENTITY pref.hint_chars.desc  "Default: FJDKSLAGHRUEIWOVNCM">
 
-<!ENTITY pref.black_list.title      "Black List">
-<!ENTITY pref.black_list.desc       "Comma separated list of URL where VimFx should be automatically disabled.
+<!ENTITY pref.hint_chars_ignore_case.title "Hint Chars Ignore Case">
+<!ENTITY pref.hint_chars_ignore_case.desc  "Treat lowercase and uppercase letters as the same char">
+
+<!ENTITY pref.black_list.title "Black List">
+<!ENTITY pref.black_list.desc  "Comma separated list of URL where VimFx should be automatically disabled.
 Wildcards allowed: *, !. Default: *mail.google.com*">
 
 <!ENTITY pref.scroll_step_lines.title "Scroll Step">

--- a/extension/locale/hu/options.dtd
+++ b/extension/locale/hu/options.dtd
@@ -1,11 +1,14 @@
-<!ENTITY pref.hint_chars.title      "Segéd karakterek">
-<!ENTITY pref.hint_chars.desc       "Alapértelmezett: fjdkslaghrueiwovncm">
+<!ENTITY pref.hint_chars.title "Segéd karakterek">
+<!ENTITY pref.hint_chars.desc  "Alapértelmezett: FJDKSLAGHRUEIWOVNCM">
 
-<!ENTITY pref.black_list.title      "Fekete lista">
-<!ENTITY pref.black_list.desc       "Vesszővel elválasztott URL-ek, ahol a VimFX inaktív legyen. Helyettesítő karakterek is használhatók: *, !. Alapértelmezett: *mail.google.com*">
+<!ENTITY pref.hint_chars_ignore_case.title "Hint Chars Ignore Case">
+<!ENTITY pref.hint_chars_ignore_case.desc  "Treat lowercase and uppercase letters as the same char">
 
-<!ENTITY pref.scroll_step_lines.title   "Görgetés mértéke">
-<!ENTITY pref.scroll_step_lines.desc    "Görgetés mértéke">
+<!ENTITY pref.black_list.title "Fekete lista">
+<!ENTITY pref.black_list.desc  "Vesszővel elválasztott URL-ek, ahol a VimFX inaktív legyen. Helyettesítő karakterek is használhatók: *, !. Alapértelmezett: *mail.google.com*">
+
+<!ENTITY pref.scroll_step_lines.title "Görgetés mértéke">
+<!ENTITY pref.scroll_step_lines.desc  "Görgetés mértéke">
 
 <!ENTITY pref.hints_bloom_on.title "Smart hint assignment (needs translation)">
 <!ENTITY pref.hints_bloom_on.desc  "Assign shorter hints to the links that users visit most often (needs translation)">

--- a/extension/locale/id/options.dtd
+++ b/extension/locale/id/options.dtd
@@ -1,12 +1,15 @@
-<!ENTITY pref.hint_chars.title      "Karakter petunjuk">
-<!ENTITY pref.hint_chars.desc       "Default: fjdkslaghrueiwovncm">
+<!ENTITY pref.hint_chars.title "Karakter petunjuk">
+<!ENTITY pref.hint_chars.desc  "Default: FJDKSLAGHRUEIWOVNCM">
 
-<!ENTITY pref.black_list.title      "Daftar Larangan">
-<!ENTITY pref.black_list.desc       "Daftar terpisah koma dari URL dimana VimFx harus nonaktif otomatis.
+<!ENTITY pref.hint_chars_ignore_case.title "Hint Chars Ignore Case">
+<!ENTITY pref.hint_chars_ignore_case.desc  "Treat lowercase and uppercase letters as the same char">
+
+<!ENTITY pref.black_list.title "Daftar Larangan">
+<!ENTITY pref.black_list.desc  "Daftar terpisah koma dari URL dimana VimFx harus nonaktif otomatis.
 Wildcard dibolehkan: *, !. Default: *mail.google.com*">
 
-<!ENTITY pref.scroll_step_lines.title     "Langkah Gulung">
-<!ENTITY pref.scroll_step_lines.desc      "Langkah Gulung">
+<!ENTITY pref.scroll_step_lines.title "Langkah Gulung">
+<!ENTITY pref.scroll_step_lines.desc  "Langkah Gulung">
 
 <!ENTITY pref.hints_bloom_on.title "Penempatan petunjuk cerdas">
 <!ENTITY pref.hints_bloom_on.desc  "Menempatkan petunjuk lebih pendek untuk pranala yang sering dikunjungi">

--- a/extension/locale/nl/options.dtd
+++ b/extension/locale/nl/options.dtd
@@ -1,12 +1,15 @@
-<!ENTITY pref.hint_chars.title      "Gebruikte karakters">
-<!ENTITY pref.hint_chars.desc       "Standaard: fjdkslaghrueiwovncm">
+<!ENTITY pref.hint_chars.title "Gebruikte karakters">
+<!ENTITY pref.hint_chars.desc  "Standaard: FJDKSLAGHRUEIWOVNCM">
 
-<!ENTITY pref.black_list.title      "Zwarte lijst">
-<!ENTITY pref.black_list.desc       "Door komma's gescheiden lijst van adressen waarop VimFx automatisch uitgeschakeld moet worden.
+<!ENTITY pref.hint_chars_ignore_case.title "Hint Chars Ignore Case">
+<!ENTITY pref.hint_chars_ignore_case.desc  "Treat lowercase and uppercase letters as the same char">
+
+<!ENTITY pref.black_list.title "Zwarte lijst">
+<!ENTITY pref.black_list.desc  "Door komma's gescheiden lijst van adressen waarop VimFx automatisch uitgeschakeld moet worden.
 Speciale tekens toegestaan: *, !. Standaard: *mail.google.com*">
 
-<!ENTITY pref.scroll_step_lines.title   "Scrollstapgrootte">
-<!ENTITY pref.scroll_step_lines.desc    "Scrollstapgrootte">
+<!ENTITY pref.scroll_step_lines.title "Scrollstapgrootte">
+<!ENTITY pref.scroll_step_lines.desc  "Scrollstapgrootte">
 
 <!ENTITY pref.hints_bloom_on.title "Smart hint assignment (needs translation)">
 <!ENTITY pref.hints_bloom_on.desc  "Assign shorter hints to the links that users visit most often (needs translation)">

--- a/extension/locale/pl/options.dtd
+++ b/extension/locale/pl/options.dtd
@@ -1,12 +1,15 @@
-<!ENTITY pref.hint_chars.title      "Znaki podpowiedzi">
-<!ENTITY pref.hint_chars.desc       "Domyślnie: fjdkslaghrueiwovncm">
+<!ENTITY pref.hint_chars.title "Znaki podpowiedzi">
+<!ENTITY pref.hint_chars.desc  "Domyślnie: FJDKSLAGHRUEIWOVNCM">
 
-<!ENTITY pref.black_list.title      "Czarna lista">
-<!ENTITY pref.black_list.desc       "Lista adresów oddzielonych przecinkami pod którymi VimFx powinien być automatycznie wyłączony.
+<!ENTITY pref.hint_chars_ignore_case.title "Hint Chars Ignore Case">
+<!ENTITY pref.hint_chars_ignore_case.desc  "Treat lowercase and uppercase letters as the same char">
+
+<!ENTITY pref.black_list.title "Czarna lista">
+<!ENTITY pref.black_list.desc  "Lista adresów oddzielonych przecinkami pod którymi VimFx powinien być automatycznie wyłączony.
 Dopuszczalne wieloznaczniki: *, !. Domyślnie: *mail.google.com*">
 
-<!ENTITY pref.scroll_step_liens.title   "Krok przewijania">
-<!ENTITY pref.scroll_step_lines.desc    "Krok przewijania">
+<!ENTITY pref.scroll_step_liens.title "Krok przewijania">
+<!ENTITY pref.scroll_step_lines.desc  "Krok przewijania">
 
 <!ENTITY pref.hints_bloom_on.title "Smart hint assignment">
 <!ENTITY pref.hints_bloom_on.desc  "Assign shorter hints to the links that users visit most often">

--- a/extension/locale/ru/options.dtd
+++ b/extension/locale/ru/options.dtd
@@ -1,12 +1,15 @@
-<!ENTITY pref.hint_chars.title      "Символы на маркерах">
-<!ENTITY pref.hint_chars.desc       "По умолчанию: fjdkslaghrueiwovncm">
+<!ENTITY pref.hint_chars.title "Символы на маркерах">
+<!ENTITY pref.hint_chars.desc  "По умолчанию: FJDKSLAGHRUEIWOVNCM">
 
-<!ENTITY pref.black_list.title      "Стоп список">
-<!ENTITY pref.black_list.desc       "Список адесов, разделенных запятой, на которых VimFx не активен.
+<!ENTITY pref.hint_chars_ignore_case.title "Hint Chars Ignore Case">
+<!ENTITY pref.hint_chars_ignore_case.desc  "Treat lowercase and uppercase letters as the same char">
+
+<!ENTITY pref.black_list.title "Стоп список">
+<!ENTITY pref.black_list.desc  "Список адесов, разделенных запятой, на которых VimFx не активен.
 Разрешены одстановки: *, !. По умолчанию: *mail.google.com*">
 
-<!ENTITY pref.scroll_step_lines.title   "Шаг прокрутки страницы">
-<!ENTITY pref.scroll_step_lines.desc    "По умолчанию: 6">
+<!ENTITY pref.scroll_step_lines.title "Шаг прокрутки страницы">
+<!ENTITY pref.scroll_step_lines.desc  "По умолчанию: 6">
 
 <!ENTITY pref.hints_bloom_on.title "Умное распределение маркеров">
 <!ENTITY pref.hints_bloom_on.desc  "Назначать короткие маркеры ссылкам и элементам, которые часто используются">

--- a/extension/locale/zh-CN/options.dtd
+++ b/extension/locale/zh-CN/options.dtd
@@ -1,12 +1,15 @@
-<!ENTITY pref.hint_chars.title      "提示符（Hint Chars）">
-<!ENTITY pref.hint_chars.desc       "默认：fjdkslaghrueiwovncm">
+<!ENTITY pref.hint_chars.title "提示符（Hint Chars）">
+<!ENTITY pref.hint_chars.desc  "默认：FJDKSLAGHRUEIWOVNCM">
 
-<!ENTITY pref.black_list.title      "黑名单">
-<!ENTITY pref.black_list.desc       "当访问列表中的 URL（逗号分隔）时，VimFx 将被自动禁用。
+<!ENTITY pref.hint_chars_ignore_case.title "Hint Chars Ignore Case">
+<!ENTITY pref.hint_chars_ignore_case.desc  "Treat lowercase and uppercase letters as the same char">
+
+<!ENTITY pref.black_list.title "黑名单">
+<!ENTITY pref.black_list.desc  "当访问列表中的 URL（逗号分隔）时，VimFx 将被自动禁用。
 允许的通配符：*, !. 默认：*mail.google.com*">
 
-<!ENTITY pref.scroll_step_lines.title   "滚动步长">
-<!ENTITY pref.scroll_step_lines.desc    "滚动步长">
+<!ENTITY pref.scroll_step_lines.title "滚动步长">
+<!ENTITY pref.scroll_step_lines.desc  "滚动步长">
 
 <!ENTITY pref.hints_bloom_on.title "智能分配提示符">
 <!ENTITY pref.hints_bloom_on.desc  "为最常访问的链接分配更短的提示符">

--- a/extension/options.xul
+++ b/extension/options.xul
@@ -5,6 +5,8 @@
 <vbox xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
     <setting pref="extensions.VimFx.hint_chars" type="string"
         title="&pref.hint_chars.title;" desc="&pref.hint_chars.desc;" />
+    <setting pref="extensions.VimFx.hint_chars_ignore_case" type="bool"
+        title="&pref.hint_chars_ignore_case.title;" desc="&pref.hint_chars_ignore_case.desc;" />
     <setting pref="extensions.VimFx.black_list" type="string"
         title="&pref.black_list.title;" desc="&pref.black_list.desc;" />
     <setting pref="extensions.VimFx.scroll_step_lines" type="integer"

--- a/extension/packages/mode-hints/marker.coffee
+++ b/extension/packages/mode-hints/marker.coffee
@@ -2,6 +2,7 @@
 , DummyBloomFilter } = require 'mode-hints/bloomfilter'
 
 { getPref } = require 'prefs'
+utils       = require 'utils'
 
 HTMLDocument      = Ci.nsIDOMHTMLDocument
 HTMLAnchorElement = Ci.nsIDOMHTMLAnchorElement
@@ -68,7 +69,7 @@ class Marker
     for char in @hintChars
       span = document.createElement('span')
       span.className = 'VimFxReset'
-      span.textContent = char.toUpperCase()
+      span.textContent = char
       fragment.appendChild(span)
 
     @markerElement.appendChild(fragment)
@@ -86,7 +87,7 @@ class Marker
       offset = 0
     else
       method = 'add'
-      @enteredHintChars += char.toLowerCase()
+      @enteredHintChars += char
       offset = -1
 
     @markerElement.children[@enteredHintChars.length + offset]?.classList[method]('VimFxCharMatch')

--- a/extension/packages/mode-hints/mode-hints.coffee
+++ b/extension/packages/mode-hints/mode-hints.coffee
@@ -1,3 +1,4 @@
+{ getPref } = require 'prefs'
 utils = require 'utils'
 hints = require 'mode-hints/hints'
 
@@ -34,6 +35,8 @@ exports.mode_hints =
           marker.deleteHintChar()
 
       else
+        if getPref('hint_chars_ignore_case')
+          keyStr = keyStr.toUpperCase()
         return false if keyStr not in utils.getHintChars() or event.ctrlKey or event.metaKey
         for marker in markers
           marker.matchHintChar(keyStr)

--- a/extension/packages/options.coffee
+++ b/extension/packages/options.coffee
@@ -11,30 +11,44 @@ observer =
     return unless addon == getPref('addon_id')
 
     hintCharsInput = document.querySelector('setting[pref="extensions.VimFx.hint_chars"]')
+    hintCharsCheckbox = document.querySelector('setting[pref="extensions.VimFx.hint_chars_ignore_case"]')
     blacklistInput = document.querySelector('setting[pref="extensions.VimFx.black_list"]')
 
     customizeButton = document.getElementById('customizeButton')
     injectHelp = help.injectHelp.bind(undefined, document, commands)
 
+    lastHintChars = undefined
+
+    filterChars = (event) ->
+      hintCharsInput.value = utils.removeDuplicateCharacters(hintCharsInput.value).replace(/\s/g, '')
+      hintCharsInput.valueToPreference()
+      if event
+        lastHintChars = hintCharsInput.value
+
+    toUpperCase = ->
+      if getPref('hint_chars_ignore_case')
+        hintCharsInput.value = hintCharsInput.value.toUpperCase()
+
+    reflectIgnoreCase = ->
+      if lastHintChars
+        hintCharsInput.value = lastHintChars
+      toUpperCase()
+      filterChars()
+
     switch topic
       when 'addon-options-displayed'
         hintCharsInput.addEventListener('change', filterChars, false)
-        blacklistInput.addEventListener('change', validateBlacklist, false)
+        hintCharsInput.addEventListener('input', toUpperCase, false)
+        hintCharsCheckbox.addEventListener('command', reflectIgnoreCase, false)
+        blacklistInput.addEventListener('change', utils.updateBlacklist, false)
         customizeButton.addEventListener('command', injectHelp, false)
 
       when 'addon-options-hidden'
         hintCharsInput.removeEventListener('change', filterChars, false)
-        blacklistInput.removeEventListener('change', validateBlacklist, false)
+        hintCharsInput.removeEventListener('input', filterCharsFoo, false)
+        hintCharsCheckbox.removeEventListener('command', reflectIgnoreCase, false)
+        blacklistInput.removeEventListener('change', utils.updateBlacklist, false)
         customizeButton.removeEventListener('command', injectHelp, false)
-
-filterChars = (event) ->
-  input = event.target
-  input.value = utils.removeDuplicateCharacters(input.value).replace(/\s/g, '')
-  input.valueToPreference()
-
-validateBlacklist = (event) ->
-  input = event.target
-  utils.updateBlacklist()
 
 observe = ->
   Services.obs.addObserver(observer, 'addon-options-displayed', false)

--- a/extension/packages/prefs.coffee
+++ b/extension/packages/prefs.coffee
@@ -8,13 +8,14 @@ PREF_BRANCH = 'extensions.VimFx.'
 # All used preferences should be mentioned here becuase
 # preference type is derived from here
 DEFAULT_PREF_VALUES =
-  addon_id:           'VimFx@akhodakivskiy.github.com'
-  hint_chars:         'fjdkslaghrueiwovncm' # preferably use letters only
-  disabled:           false
-  scroll_step_lines:  6
-  black_list:         '*mail.google.com*'
-  hints_bloom_data:   ''
-  hints_bloom_on:     true
+  addon_id:               'VimFx@akhodakivskiy.github.com'
+  hint_chars:             'FJDKSLAGHRUEIWOVNCM' # preferably use letters only
+  hint_chars_ignore_case: true
+  disabled:               false
+  scroll_step_lines:      6
+  black_list:             '*mail.google.com*'
+  hints_bloom_data:       ''
+  hints_bloom_on:         true
 
 
 getBranchPref = (branch, key, defaultValue) ->

--- a/extension/packages/utils.coffee
+++ b/extension/packages/utils.coffee
@@ -281,17 +281,21 @@ browserSearchSubmission = (str) ->
   return engine.getSubmission(str, null)
 
 # Get hint characters, convert them to lower case and fall back
-# to default hint characters if there are less than 3 chars
+# to default hint characters if there are less than 2 chars
 getHintChars = ->
-  hintChars = removeDuplicateCharacters(getPref('hint_chars'))
+  hintChars = getPref('hint_chars')
+  if getPref('hint_chars_ignore_case')
+    hintChars = hintChars.toUpperCase()
+  hintChars = removeDuplicateCharacters(hintChars)
+
   if hintChars.length < 2
     hintChars = getDefaultPref('hint_chars')
 
   return hintChars
 
-# Remove duplicate characters from string (case insensitive)
+# Remove duplicate characters from string
 removeDuplicateCharacters = (str) ->
-  return removeDuplicates( str.toLowerCase().split('') ).join('')
+  return removeDuplicates( str.split('') ).join('')
 
 # Return URI to some file in the extension packaged as resource
 getResourceURI = do ->


### PR DESCRIPTION
The old behavior (always show hint chars as uppercase, allow lowercase
letters to match) is on by default, but can be switched off by a new
setting. Then the hint chars are shown as-is, and the matching is case
sensitive.
