### PR TITLE
Make button click depend on current mode. Fix #243

### DIFF
--- a/extension/bootstrap.coffee
+++ b/extension/bootstrap.coffee
@@ -40,7 +40,8 @@ do (global = this) ->
   global.startup = (data, reason) ->
     # Requires for startup/install
     { loadCss }             = require 'utils'
-    { addEventListeners }   = require 'events'
+    { addEventListeners
+    , vimBucket }           = require 'events'
     { getPref
     , initPrefValues }      = require 'prefs'
     { setButtonInstallPosition
@@ -62,7 +63,7 @@ do (global = this) ->
     options.observe()
 
     watchWindows(addEventListeners, 'navigator:browser')
-    watchWindows(addToolbarButton, 'navigator:browser')
+    watchWindows(addToolbarButton.bind(undefined, vimBucket), 'navigator:browser')
 
     unload(release)
 

--- a/extension/locale/de/vimfx.properties
+++ b/extension/locale/de/vimfx.properties
@@ -1,7 +1,7 @@
 button_tooltip_enabled=VimFx ist aktiviert. Zum Deaktivieren hier klicken. (shift-alt-v)
 button_tooltip_disabled=VimFx ist deaktiviert. Zum Aktivieren hier klicken. (shift-alt-v)
 button_tooltip_blacklisted=Diese Seite ist auf der schwarzen Liste
-button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Press Esc (by default) to exit
+button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Click to exit (Esc [by default])
 item_preferences=Einstellungen
 item_blacklist_button_tooltip=Schwarze Liste
 item_blacklist_button_inverse_tooltip=Remove this rule

--- a/extension/locale/el-GR/vimfx.properties
+++ b/extension/locale/el-GR/vimfx.properties
@@ -1,7 +1,7 @@
 button_tooltip_enabled=Το VimFx είναι ενεργοποιημένο. Κάντε κλικ για να το απενεργοποιήσετε (shift-alt-v)
 button_tooltip_disabled=Το VimFx είναι απενεργοποιημένο. Κάντε κλικ για να το ενεργοποιήσετε (shift-alt-v)
 button_tooltip_blacklisted=Το VimFx είναι στην μαύρη λίστα σε αυτήν την σελίδα.
-button_tooltip_insertMode=Το VimFx είναι σε λειτουργία εισαγωγής (insert mode) σε αυτή τη Σελίδα: Όλες οι εντολές αγνοούνται. Πατήστε Esc (προεπιλογμένο) για να βγείτε
+button_tooltip_insertMode=Το VimFx είναι σε λειτουργία εισαγωγής (insert mode) σε αυτή τη Σελίδα: Όλες οι εντολές αγνοούνται. Κάντε κλικ για να βγείτε (Esc [προεπιλεγμένο])
 item_preferences=Προτιμήσεις
 item_blacklist_button_tooltip=Μαύρη Λίστα
 item_blacklist_button_inverse_tooltip=Κατάργηση αυτού του κανόνα

--- a/extension/locale/en-US/vimfx.properties
+++ b/extension/locale/en-US/vimfx.properties
@@ -1,7 +1,7 @@
 button_tooltip_enabled=VimFx is Enabled. Click to Disable (shift-alt-v)
 button_tooltip_disabled=VimFx is Disabled. Click to Enable (shift-alt-v)
 button_tooltip_blacklisted=VimFx is Blacklisted on this Page
-button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Press Esc (by default) to exit
+button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Click to exit (Esc [by default])
 item_preferences=Preferences
 item_blacklist_button_tooltip=Blacklist
 item_blacklist_button_inverse_tooltip=Remove this rule

--- a/extension/locale/hu/vimfx.properties
+++ b/extension/locale/hu/vimfx.properties
@@ -1,7 +1,7 @@
 button_tooltip_enabled=VimFx aktív. Kattints az inaktiváláshoz (shift-alt-v)
 button_tooltip_disabled=VimFx inaktív. Kattints az aktiváláshoz (shift-alt-v)
 button_tooltip_blacklisted=Az oldal feketelistázva a VimFX-ben.
-button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Press Esc (by default) to exit
+button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Click to exit (Esc [by default])
 item_preferences=Beállítások
 item_blacklist_button_tooltip=Feketelista
 item_blacklist_button_inverse_tooltip=Remove this rule

--- a/extension/locale/id/vimfx.properties
+++ b/extension/locale/id/vimfx.properties
@@ -1,7 +1,7 @@
 button_tooltip_enabled=VimFx telah Aktif. Klik untuk Nonaktifkan (shift-alt-v)
 button_tooltip_disabled=VimFx telah Nonaktif. Klik untuk Aktifkan (shift-alt-v)
 button_tooltip_blacklisted=VimFx telah Dilarang pada halaman ini
-button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Press Esc (by default) to exit
+button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Click to exit (Esc [by default])
 item_preferences=Preferensi
 item_blacklist_button_tooltip=Larangan
 item_blacklist_button_inverse_tooltip=Remove this rule

--- a/extension/locale/nl/vimfx.properties
+++ b/extension/locale/nl/vimfx.properties
@@ -1,7 +1,7 @@
 button_tooltip_enabled=VimFx is ingeschakeld. Klik om uit te schakelen (shift-alt-v)
 button_tooltip_disabled=VimFx is uitgeschakeld. Klik om in te schakelen (shift-alt-v)
 button_tooltip_blacklisted=VimFx is uitgeschakeld op deze pagina
-button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Press Esc (by default) to exit
+button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Click to exit (Esc [by default])
 item_preferences=Instellingen
 item_blacklist_button_tooltip=Zwarte lijst
 item_blacklist_button_inverse_tooltip=Remove this rule

--- a/extension/locale/pl/vimfx.properties
+++ b/extension/locale/pl/vimfx.properties
@@ -1,7 +1,7 @@
 button_tooltip_enabled=VimFx jest włączony. Kliknij, aby wyłączyć (shift-alt-v)
 button_tooltip_disabled=VimFx jest wyłączony. Kliknij, aby włączyć (shift-alt-v)
 button_tooltip_blacklisted=Ta strona jest na czarnej liście VimFx
-button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Press Esc (by default) to exit
+button_tooltip_insertMode=VimFx is in insert mode on this Page: All commands are ignored. Click to exit (Esc [by default])
 item_preferences=Preferencje
 item_blacklist_button_tooltip=Czarna lista
 item_blacklist_button_inverse_tooltip=Remove this rule

--- a/extension/locale/ru/vimfx.properties
+++ b/extension/locale/ru/vimfx.properties
@@ -1,7 +1,7 @@
 button_tooltip_enabled=VimFx работает. Нажмите чтобы выключить (shift-alt-v)
 button_tooltip_disabled=VimFx не работает. Нажмите чтобы включить (shift-alt-v)
 button_tooltip_blacklisted=VimFx содержит текущую страницу в стоп-списке
-button_tooltip_insertMode=VimFx в режиме ввода на этой странице: все команды игнорируются. Нажмите Esc для выхода
+button_tooltip_insertMode=VimFx в режиме ввода на этой странице: все команды игнорируются. Нажмите чтобы для выхода (Esc)
 item_preferences=Настройки
 item_blacklist_button_tooltip=Добавить в стоп-список
 item_blacklist_button_inverse_tooltip=Убрать эту комбинацию

--- a/extension/locale/zh-CN/vimfx.properties
+++ b/extension/locale/zh-CN/vimfx.properties
@@ -1,7 +1,7 @@
 button_tooltip_enabled=VimFx 已启用。点击禁用 (shift-alt-v)
 button_tooltip_disabled=VimFx 已禁用。点击启用 (shift-alt-v)
 button_tooltip_blacklisted=当前页面已被列入黑名单
-button_tooltip_insertMode=VimFx 在当前页面处于插入模式：所有命令都将被忽略。按下 Esc（默认）键退出插入模式
+button_tooltip_insertMode=VimFx 在当前页面处于插入模式：所有命令都将被忽略。点击退出（Esc［默认］）
 item_preferences=首选项
 item_blacklist_button_tooltip=添加到黑名单
 item_blacklist_button_inverse_tooltip=移除此规则

--- a/extension/packages/events.coffee
+++ b/extension/packages/events.coffee
@@ -112,3 +112,4 @@ addEventListeners = (window) ->
     window.gBrowser.removeTabsProgressListener(tabsListener)
 
 exports.addEventListeners = addEventListeners
+exports.vimBucket         = vimBucket


### PR DESCRIPTION
Both insert mode and disabled mode use the same greyed out icon for the
toolbar button. If you're in insert mode and click the button, we used to
disable the extension as normal. However, it felt like clicking the button
did nothing, because the icon didn't change. Even if it _would_ change, it
feels more natural if the extension is _enabled_ again at that point. So
now, if you're in insert mode and click the button, we enter normal mode.
(#243)

If the current site is blacklisted, clicking the button used to disable
the extension. Well, it was already disabled, but the button icon changed
from the blacklisted icon (red) to the disabled icon (grey). Clicking
again went back to blacklisted mode. That's pretty weird. Now we open the
menu popup when clicked instead, which will show the trash can icon which
is used to un-blacklist the site. Un-blacklisting directly when clicking
the button would be to go too far, since that can potentially remove more
blacklisting rules than the user wants to. Using the popup you have a
chance to review what will be removed when un-blacklisting.

To sum up, the button clicking is more intuitive now:
- If enabled: Disable
- Otherwise: Enable (almost)
