### PR TITLE
follow ref link type first in follow prev/next links

### DIFF
--- a/extension/packages/commands.coffee
+++ b/extension/packages/commands.coffee
@@ -205,7 +205,7 @@ helper_follow_pattern = (type, vim) ->
     .filter(utils.isElementVisible)
 
   # matching link type (rel="prev/next")
-  relLink = links.find((link) -> link.rel.toLowerCase().split(" ").indexOf(type) != -1)
+  relLink = links.find((link) -> link.rel?.toLowerCase().contains(type))
   if relLink
     utils.simulateClick(relLink, {metaKey: false, ctrlKey: false})
     return


### PR DESCRIPTION
Based on the discussion in #280, as suggested by @esseb:

> `<link rel="next" ...>` and `<a href="..." rel="next">` should be prioritized over reading link text. Reading link text should only be a fallback if there is no "link" or "a" elements on the page with `rel="prev"` or `rel="next"` attributes. This would fix the stackoverflow pagination at least.
> 
> Reference:
>    https://support.google.com/webmasters/answer/1663744?hl=en
>    http://www.w3.org/TR/html5/links.html#linkTypes

Now add link type matching when follow prev/next links.
- `rel` is split on space because there may has multiple rel and these the element's rel attribute must be split on spaces
