### PR TITLE
Fix autofocus

### DIFF
--- a/extension/packages/events.coffee
+++ b/extension/packages/events.coffee
@@ -109,7 +109,6 @@ windowsListeners =
     # DOMContentLoaded already has fired we blur only if the focus happens
     # within a second after it.
     if !vim.lastLoad or Date.now() - vim.lastLoad < 1000
-      console.log 'blur'
       target.blur()
 
   # Record when the page was loaded. This is used by the autofocus prevention feature.
@@ -125,7 +124,6 @@ windowsListeners =
     # focused something on his own.
     if !vim.lastLoad
       vim.lastLoad = Date.now()
-    console.log vim.lastLoad
     return
 
   # When the top level window closes we should release all Vims that were


### PR DESCRIPTION
Autofocus was broken by some Firefox update, possibly version 29. This
commit fixes it again. It also fixes a bug where autofocus was prevented
even on blacklisted sites, and cleans the code a bit.

@akhodakivskiy, could you please take a look at this as soon as possible? I’m afraid that I messed something up. But it seems to work nicely. When this is merged I want to make a new release, so we finally get a version that fixes the most important Firefox 29 related bugs.
