### PR TITLE
[WIP] Use `event.key` instead of `event.keyCode`

### DIFF
--- a/extension/packages/events.coffee
+++ b/extension/packages/events.coffee
@@ -15,7 +15,7 @@ keyStrFromEvent = (event) ->
   { ctrlKey: ctrl, metaKey: meta, altKey: alt, shiftKey: shift } = event
 
   if !meta and !alt
-    return unless keyChar = keyUtils.keyCharFromCode(event.keyCode, shift)
+    return unless keyChar = keyUtils.keyCharFromCode(event.key, shift)
     keyStr = keyUtils.applyModifiers(keyChar, ctrl, alt, meta)
     return keyStr
 


### PR DESCRIPTION
`event.key` has the following benefits:
- It recognizes almost any key on the keyboard, allowing us to easily
  support F1–F12, the keypad, international punctuation keys etc.
- It supports other keyboard layouts than en-US QWERTY.

This commit switches to `event.key` and tries to do so with as few
changes as possible and in a backwards compatible way. We should
refactor some things in the future.

---

Making use of `event.key` was really simple. The problem that remains is keyboard layouts that don’t include A–Z.

@akhodakivskiy (or anyone, really):
- You use a Russian keyboard layout, right?
- Do you also use en-US QWERTY? If so, how often do you switch between them?
- Currently, if you use a Russian layout, can you use VimFx’s hints mode? I.e. can you enter hints such as ‘fja’?
- Do you use VimFx commands by character or key: Let’s say that `/` is in a different position in a Russian layout than en-US QWERTY—do you type the `/` according to the current layout, or do you prefer hitting the same key in both layouts (even though it produces two different chars)?
- If you would alias a Russian layout to English—would you map each letter key to its en-US QWERTY equivalent, or to a phonetically similar English letter?
