### PR TITLE
Better find mode

### DIFF
--- a/extension/packages/commands.coffee
+++ b/extension/packages/commands.coffee
@@ -245,27 +245,34 @@ command_forward = (vim) ->
 
 findStorage = { lastSearchString: '' }
 
-# Switch into find mode
-command_find = (vim) ->
-  vim.enterMode('find', { highlight: false })
+helper_find = (highlight, vim) ->
+  findBar = vim.rootWindow.gBrowser.getFindBar()
 
-# Switch into find mode with highlighting
-command_find_hl = (vim) ->
-  vim.enterMode('find', { highlight: true })
+  findBar.onFindCommand()
+  findBar._findField.focus()
+  findBar._findField.select()
+
+  return unless highlightButton = findBar.getElement('highlight')
+  if highlightButton.checked != highlight
+    highlightButton.click()
+
+# Open the find bar, making sure that hightlighting is off.
+command_find = helper_find.bind(undefined, false)
+
+# Open the find bar, making sure that hightlighting is on.
+command_find_hl = helper_find.bind(undefined, true)
+
+helper_find_again = (direction, vim) ->
+  findBar = vim.rootWindow.gBrowser.getFindBar()
+  if findStorage.lastSearchString.length > 0
+    findBar._findField.value = findStorage.lastSearchString
+    findBar.onFindAgainCommand(direction)
 
 # Search for the last pattern
-command_find_next = (vim) ->
-  if findBar = vim.rootWindow.gBrowser.getFindBar()
-    if findStorage.lastSearchString.length > 0
-      findBar._findField.value = findStorage.lastSearchString
-      findBar.onFindAgainCommand(false)
+command_find_next = helper_find_again.bind(undefined, false)
 
 # Search for the last pattern backwards
-command_find_prev = (vim) ->
-  if findBar = vim.rootWindow.gBrowser.getFindBar()
-    if findStorage.lastSearchString.length > 0
-      findBar._findField.value = findStorage.lastSearchString
-      findBar.onFindAgainCommand(true)
+command_find_prev = helper_find_again.bind(undefined, true)
 
 # Enter insert mode
 command_insert_mode = (vim) ->
@@ -291,7 +298,7 @@ command_Esc = (vim, event) ->
 
   vim.rootWindow.DeveloperToolbar.hide()
 
-  vim.rootWindow.gBrowser.getFindBar()?.close()
+  vim.rootWindow.gBrowser.getFindBar().close()
 
   vim.rootWindow.TabView.hide()
 
@@ -389,10 +396,7 @@ searchForMatchingCommand = (keys) ->
 
 isEscCommandKey = (keyStr) -> keyStr in escapeCommand.keys()
 
-isReturnCommandKey = (keyStr) -> keyStr.contains('Return')
-
 exports.commands                  = commands
 exports.searchForMatchingCommand  = searchForMatchingCommand
 exports.isEscCommandKey           = isEscCommandKey
-exports.isReturnCommandKey        = isReturnCommandKey
 exports.findStorage               = findStorage

--- a/extension/packages/vim.coffee
+++ b/extension/packages/vim.coffee
@@ -1,7 +1,5 @@
-utils                   = require 'utils'
-{ modes }               = require 'modes'
-{ isEscCommandKey
-, isReturnCommandKey }  = require 'commands'
+utils     = require 'utils'
+{ modes } = require 'modes'
 
 class Vim
   constructor: (@window) ->
@@ -26,29 +24,7 @@ class Vim
       modes[@mode].onEnter(@, @storage[@mode] ?= {}, args...)
 
   onInput: (keyStr, event) ->
-    isEditable = utils.isElementEditable(event.originalTarget)
-
-    if (isEditable or @rootWindow.TabView.isVisible()) \
-        and not (isEscCommandKey(keyStr) or isReturnCommandKey(keyStr))
-      return false
-
-    oldMode = @mode
-
     suppress = modes[@mode]?.onInput(@, @storage[@mode], keyStr, event)
-
-    # Esc key is not suppressed, and passed to the browser in `normal` mode.
-    # Here we compare against the mode that was active before the key was
-    # processed because processing the command may change the mode.
-    #
-    # Not suppressing Esc allows for stopping the loading of the page as well as
-    # closing many custom dialogs (and perhaps other things -- Esc is a very
-    # commonly used key). There are two reasons we might suppress it in other
-    # modes. If some custom dialog of a website is open, we should be able to
-    # cancel hint markers on it without closing it. Secondly, otherwise
-    # cancelling hint markers on google causes its search bar to be focused.
-    if oldMode == 'normal' and keyStr == 'Esc'
-      return false
-    else
-      return suppress
+    return suppress
 
 exports.Vim = Vim


### PR DESCRIPTION
Previously, find mode only worked if you used VimFx's shortcuts to enter
it. If you opened the find bar some other way, you weren't able to end
the search using Enter, and the n/N commands wouldn't repeat what you
just searched for.  Now, find mode is entered as soon as the findbar
input gets focused, no matter how it was focused. Find mode is also
exited as soon as the findbar input is blurred. Previously, if you
happened to unfocus the findbar without using Esc or Enter, such as
clicking or tabbing away, then you'd still be in find mode, making all
keypresses focus the findbar input rather than activate commands.

If the active element is editable during a keypress we used to pass that
keypress along to the browser -- regardless of the current mode --
instead of activating commands. The findbar input is also an editable
element, but when it is focused we want Enter to close the findbar.
Therefore we used to not pass along Enter to the browser. If the user
mapped Enter to a command, that meant that it would be impossible to
press enter in an input to type a newline, submit a search query, etc.
Now, we only use this automatic insert mode in normal mode instead.

The above also fixed another problem. We used to always pass Esc to the
browser in normal mode, even if Esc is mapped to a command. Now, that is
not done if we’re blurring an element. That makes it possible to blur an
input inside a custom dialog without closing it (Esc almost always
closes custom dialogs).  This makes it possible to use devdocs.io with
VimFx, which was very difficult before.
