### PR TITLE
Blacklist specific keys

### DIFF
--- a/extension/locale/en-US/options.dtd
+++ b/extension/locale/en-US/options.dtd
@@ -3,7 +3,8 @@
 
 <!ENTITY pref.black_list.title      "Black List">
 <!ENTITY pref.black_list.desc       "Comma separated list of URL where VimFx should be automatically disabled.
-Wildcards allowed: *, !. Example: *example.com*,*foobar.org*">
+Wildcards allowed: *, !. Example: *example.com*,*foobar.org*. To disable only specific keys use the syntax:
+pattern##key1#key2... Example: *example.com*##j#k">
 
 <!ENTITY pref.prev_patterns.title   "Previous Page Patterns">
 <!ENTITY pref.prev_patterns.desc    "Comma separated list of patterns that match links to previous page">

--- a/extension/packages/events.coffee
+++ b/extension/packages/events.coffee
@@ -232,6 +232,10 @@ tabsListener =
 
     # Update the blacklist state.
     vim.blacklisted = utils.isBlacklisted(location.spec)
+    vim.blacklistedKeys = utils.getBlacklistedKeys(location.spec)
+    # If only specific keys are blacklisted, remove blacklist state.
+    if vim.blacklistedKeys.length > 0
+      vim.blacklisted = false
     updateButton(vim)
 
 addEventListeners = (window) ->

--- a/extension/packages/modes.coffee
+++ b/extension/packages/modes.coffee
@@ -52,6 +52,9 @@ modes['normal'] =
 
     { match, exact, command, count } = searchForMatchingCommand(storage.keys)
 
+    if storage.keys.join('') in vim.blacklistedKeys
+      match = false
+
     if match
       if exact
         command.func(vim, event, count)

--- a/extension/packages/modes.coffee
+++ b/extension/packages/modes.coffee
@@ -52,7 +52,7 @@ modes['normal'] =
 
     { match, exact, command, count } = searchForMatchingCommand(storage.keys)
 
-    if storage.keys.join('') in vim.blacklistedKeys
+    if vim.blacklistedKeys and storage.keys.join('') in vim.blacklistedKeys
       match = false
 
     if match

--- a/extension/packages/utils.coffee
+++ b/extension/packages/utils.coffee
@@ -228,10 +228,18 @@ isBlacklisted = (str) ->
   matchingRules = getMatchingBlacklistRules(str)
   return (matchingRules.length != 0)
 
+# Returns all blacklisted keys in matching rules.
+getBlacklistedKeys = (str) ->
+  matchingRules = getMatchingBlacklistRules(str)
+  blacklistedKeys = []
+  for rule in matchingRules when /##/.test(rule)
+    blacklistedKeys.push(x) for x in rule.split('##')[1].split('#')
+  return blacklistedKeys
+
 # Returns all rules in the blacklist that match the provided string.
 getMatchingBlacklistRules = (str) ->
   return getBlacklist().filter((rule) ->
-    /// ^#{ simpleWildcards(rule) }$ ///i.test(str)
+    /// ^#{ simpleWildcards(rule.split('##')[0]) }$ ///i.test(str)
   )
 
 getBlacklist = ->
@@ -480,6 +488,7 @@ exports.timeIt                    = timeIt
 
 exports.getMatchingBlacklistRules = getMatchingBlacklistRules
 exports.isBlacklisted             = isBlacklisted
+exports.getBlacklistedKeys        = getBlacklistedKeys
 exports.updateBlacklist           = updateBlacklist
 exports.splitListString           = splitListString
 exports.getBestPatternMatch       = getBestPatternMatch


### PR DESCRIPTION
This allows users to set up blacklist rules for specific keys on a website using the syntax `<URL_pattern>##<Key1>#<Key2>...`. This is useful for websites which have existing mappings for VimFx shortcuts. For example, facebook and twitter support <kbd>j</kbd>/<kbd>k</kbd> for scrolling and <kbd>/</kbd> for search. This fixes #255.