### PR TITLE
Fix #440 Feedly hints

### DIFF
--- a/extension/lib/commands.coffee
+++ b/extension/lib/commands.coffee
@@ -261,7 +261,8 @@ combine = (hrefs, marker) ->
     else
       hrefs[href] = marker
   return marker
-
+  
+# Follow links, focus text inputs and click buttons with hint markers.
 command_follow = (vim, event, count, newTab, inBackground) ->
   hrefs = {}
   filter = (element, getElementShape) ->

--- a/extension/lib/commands.coffee
+++ b/extension/lib/commands.coffee
@@ -262,8 +262,7 @@ combine = (hrefs, marker) ->
       hrefs[href] = marker
   return marker
 
-# Follow links, focus text inputs and click buttons with hint markers.
-command_follow = (vim, event, count) ->
+command_follow = (vim, event, count, newTab, inBackground) ->
   hrefs = {}
   filter = (element, getElementShape) ->
     document = element.ownerDocument
@@ -323,9 +322,9 @@ command_follow = (vim, event, count) ->
     { element } = marker
     element.focus()
     last = (count == 1)
-    if not last and marker.type == 'link'
+    if not last and marker.type == 'link' or newTab
       utils.openTab(vim.rootWindow, element.href, {
-        inBackground: true
+        inBackground: inBackground
         relatedToCurrent: true
       })
     else
@@ -344,27 +343,12 @@ command_follow_multiple = (vim, event) ->
   command_follow(vim, event, Infinity)
 
 # Follow links in a new background tab with hint markers.
-command_follow_in_tab = (vim, event, count, inBackground = true) ->
-  hrefs = {}
-  filter = (element, getElementShape) ->
-    return unless isProperLink(element)
-    return unless shape = getElementShape(element)
-    return combine(hrefs, new Marker(element, shape, {semantic: true}))
-
-  callback = (marker) ->
-    last = (count == 1)
-    utils.openTab(vim.rootWindow, marker.element.href, {
-      inBackground: if last then inBackground else true
-      relatedToCurrent: true
-    })
-    count--
-    return not last
-
-  vim.enterMode('hints', filter, callback)
+command_follow_in_tab = (vim, event, count) ->
+  command_follow(vim, event, count, true, true)
 
 # Follow links in a new foreground tab with hint markers.
 command_follow_in_focused_tab = (vim, event, count) ->
-  command_follow_in_tab(vim, event, count, false)
+  command_follow(vim, event, count, true, false)
 
 # Copy the URL or text of a markable element to the system clipboard.
 command_marker_yank = (vim) ->

--- a/extension/lib/commands.coffee
+++ b/extension/lib/commands.coffee
@@ -29,7 +29,7 @@ _          = require('./l10n')
 , setPref
 , isPrefSet } = require('./prefs')
 
-{ isProperLink, isTextInputElement, isContentEditable } = utils
+{ isProperLink, isTextInputElement, isContentEditable, isDataApp } = utils
 
 { classes: Cc, interfaces: Ci, utils: Cu } = Components
 
@@ -261,7 +261,7 @@ combine = (hrefs, marker) ->
     else
       hrefs[href] = marker
   return marker
-  
+
 # Follow links, focus text inputs and click buttons with hint markers.
 command_follow = (vim, event, count, newTab, inBackground) ->
   hrefs = {}
@@ -288,7 +288,9 @@ command_follow = (vim, event, count, newTab, inBackground) ->
            element.hasAttribute('oncommand') or
            element.getAttribute('role') in ['link', 'button'] or
            # Twitter special-case.
-           element.classList.contains('js-new-tweets-bar')
+           element.classList.contains('js-new-tweets-bar') or
+           # Feedly special-case.
+           isDataApp(element)
         type = 'clickable'
         semantic = false
       # Putting markers on `<label>` elements is generally redundant, because
@@ -357,6 +359,7 @@ command_marker_yank = (vim) ->
   filter = (element, getElementShape) ->
     type = switch
       when isProperLink(element)       then 'link'
+      when isDataApp(element)          then 'link'
       when isTextInputElement(element) then 'textInput'
       when isContentEditable(element)  then 'contenteditable'
     return unless type

--- a/extension/lib/commands.coffee
+++ b/extension/lib/commands.coffee
@@ -359,7 +359,7 @@ command_marker_yank = (vim) ->
   filter = (element, getElementShape) ->
     type = switch
       when isProperLink(element)       then 'link'
-      when isDataApp(element)          then 'link'
+      when isDataApp(element)          then 'clickable'
       when isTextInputElement(element) then 'textInput'
       when isContentEditable(element)  then 'contenteditable'
     return unless type

--- a/extension/lib/commands.coffee
+++ b/extension/lib/commands.coffee
@@ -288,7 +288,9 @@ command_follow = (vim, event, count) ->
            element.hasAttribute('oncommand') or
            element.getAttribute('role') in ['link', 'button'] or
            # Twitter special-case.
-           element.classList.contains('js-new-tweets-bar')
+           element.classList.contains('js-new-tweets-bar') or
+           # Feedly special-case.
+           isDataApp(element)
         type = 'clickable'
         semantic = false
       # Putting markers on `<label>` elements is generally redundant, because

--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -120,6 +120,12 @@ isGoogleEditable = (element) ->
   return element.getAttribute?('g_editable') == 'true' or
          element.ownerDocument.body?.getAttribute('g_editable') == 'true'
 
+isDataApp = (element) ->
+  # `data-app-action and data-uri` are a non-standard attributes commonly used by Feedly.
+  return element.hasAttribute('data-app-action') or
+         element.hasAttribute('data-uri') or
+         element.hasAttribute('data-page-action')
+
 isActivatable = (element) ->
   return element instanceof HTMLAnchorElement or
          element instanceof HTMLButtonElement or
@@ -416,6 +422,7 @@ exports.blurActiveElement         = blurActiveElement
 exports.isProperLink              = isProperLink
 exports.isTextInputElement        = isTextInputElement
 exports.isContentEditable         = isContentEditable
+exports.isDataApp                 = isDataApp
 exports.isActivatable             = isActivatable
 exports.isAdjustable              = isAdjustable
 exports.area                      = area


### PR DESCRIPTION
Fix #440. Fixed generation of hints for feedly.com by adding function to check for this element attributes:
```
data-app-action
data-uri
data-page-action
```