### PR TITLE
Makes it possible to build without global gulp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,8 @@ Finally send a pull request to same branch as you based your topic branch on
 1. Install [Node.js].
 2. Run `npm install` to download dependencies and development dependencies.
 3. Run `npm install -g gulp` to be able to run [`gulp`][gulp] commands.
-   (Alternatively, you may use `./node_modules/.bin/gulp`.)
+   (If you don't want to install gulp globally, you may type `npm run gulp --`
+   instead of `gulp`)
 4. Create a new Firefox profile for development.
 5. Install the [Extension Auto-Installer] add-on in your development profile.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   },
   "license": "GPLv3",
   "private": true,
-  "scripts": {},
+  "scripts": {
+    "gulp": "gulp"
+  },
   "dependencies": {
     "n-ary-huffman": "^2.1.1",
     "vim-like-key-notation": "~0.1.3"


### PR DESCRIPTION
As can be seen on https://docs.npmjs.com/misc/scripts#path npm will
symlink gulp executables into .node_modules after you've run npm
install. This makes it possible to use gulp executable from the npm
script property so there's no need to install it globally.

All you have to do now after downloading the VimFX source-code is

  npm run build