### PR TITLE
Add support for `<late>` shortcuts

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -13,6 +13,7 @@ License"](GNU%20Free%20Documentation%20License).
 
 - [Options](options.md)
 - [Commands](commands.md)
+- [Shortcuts](shortcuts.md)
 - [Styling](styling.md)
 - [Handy standard Firefox features](handy-standard-firefox-features.md)
 - [Questions & Answers](questions-and-answers.md)

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -431,8 +431,13 @@ A `match` object has the following properties:
 
 - count: `Number`. The count for the command. `undefined` if no count.
 
-- force: `Boolean`. Indicates if the current key sequence started with
-  `<force>`.
+- specialKeys: `Object`. The keys may be any of the following:
+
+  - `<force>`
+  - `<late>`
+
+  If a key exists, its value is always `true`. The keys that exist indicate the
+  [special keys] for the sequence used for the matched command (if any).
 
 - keyStr: `String`. The current keypress represented as a string.
 
@@ -537,6 +542,8 @@ and won’t be broken until VimFx 2.0.0.
 [autofocus prevention]: options.md#prevent-autofocus
 [`activatable_element_keys`]: options.md#activatable_element_keys
 [`adjustable_element_keys`]: options.md#adjustable_element_keys
+
+[special keys]: shortcuts.md#special-keys
 
 [defaults.coffee]: ../extension/lib/defaults.coffee
 [parse-prefs.coffee]: ../extension/lib/parse-prefs.coffee

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -9,6 +9,11 @@ See the file README.md for copying conditions.
 Most of VimFx’s commands are straight-forward enough to not need any
 documentation. For some commands, though, there is a bit more to know.
 
+In this document, many commands are referred to by their default shortcut. You
+can of course [change those] if you like.
+
+[change those]: shortcuts.md
+
 ## Counts
 
 Some commands support _counts._ That means that you can type a number before a
@@ -67,23 +72,6 @@ Explained in the their own section below.
 Explained in its own section below.
 
 
-## `<force>` commands
-
-By putting the special “key” `<force>` at the beginning of a shortcut the
-shortcut will work exactly as it would without `<force>`, except that it will
-also be available in text inputs.
-
-VimFx enters a kind of “automatic insert mode” when you focus a text input,
-allowing you to type text into it without triggering VimFx commands. The `esc`
-command, however, is still available, allowing you to blur the text input by
-pressing `<escape>`. The reason it is available is because the default shortcut
-is `<force><escape>`.
-
-Using `<force>` allows you to run other commands in text inputs as well. For
-example, you could use `<force><a-j>` and `<force><a-k>` to be able to select
-tab backward and forward regardless if you happen to be in a text input or not.
-
-
 ## Scrolling commands
 
 Firefox lets you scroll with the arrow keys, page down, page up, home, end and
@@ -113,11 +101,13 @@ of the page, regradless of which input you used last.
 
 ## Focus next/previous element
 
-The default shorcuts are `<tab>` and `<s-tab>`, respectively. They work just
-like `<tab>` works normally, except that if you focused a text input using the
-`gi` command they will only switch between text inputs on thee page, as opposed
-to between all focusable elements (such as links, buttons and checkboxes) as
-they do otherwise.
+The default shorcuts are `<tab>` and `<s-tab>`, respectively (to be precise,
+they also include [special keys]). They work just like `<tab>` works normally,
+except that if you focused a text input using the `gi` command they will only
+switch between text inputs on thee page, as opposed to between all focusable
+elements (such as links, buttons and checkboxes) as they do otherwise.
+
+[special keys]: shortcuts.md#special-keys
 
 
 ## The `f` commands

--- a/documentation/options.md
+++ b/documentation/options.md
@@ -17,7 +17,10 @@ You might also be interested [styling] VimFx and writing a [config file].
 
 ## Regular options
 
-These options are available in VimFx’s settings page in the Add-ons Manager.
+These options are available in VimFx’s settings page in the Add-ons Manager
+(where you can also customize all [keyboard shortcuts]).
+
+[keyboard shortcuts]: shortcuts.md
 
 ### Hint chars
 

--- a/documentation/shortcuts.md
+++ b/documentation/shortcuts.md
@@ -1,0 +1,111 @@
+<!--
+This is part of the VimFx documentation.
+Copyright Simon Lydell 2015.
+See the file README.md for copying conditions.
+-->
+
+# Shortcuts
+
+All of VimFx’s keyboard shortcuts can be customized in VimFx’s settings page in
+the Add-ons Manager. Doing so is really easy. You get far just by looking at the
+defaults and trying things out. If not, read on.
+
+## Key notation
+
+VimFx’s key notation is inspired by Vim’s key notation. An example:
+
+    J  gT  <c-s-tab>  g<left>  <c-j>
+
+The above defines five alternative shortcuts. The odd ones consist of one key
+each, while the even ones consist of two. Letters can be written as they are,
+while non-letter keys like Tab and the arrow keys need to be put inside `<` and
+`>`. Letters also need to be put inside `<` and `>` if you want to specify a
+modifier (as in the `<c-j>` example, which might be notated as “CTRL+J” in some
+other programs.)
+
+If you’re usure on how to express a key press you’d like to use as part of a
+shortcut, press `<c-q>` while inside one of the text inputs for a command and
+then press your desired key (optionally holding modifier keys). That will paste
+the key notation for that particular key press into the text input. `<c-d>`
+pastes the default shortcut(s), and `<c-r>` resets the text input to the default
+entirely. You can of course use the standard `<c-z>` to undo.
+
+You can specify any number of shortcuts for every command. Separate them from
+each other by one or more spaces.
+
+A _shortcut_ consists of one or more _keys_ that you need to press in order to
+activate the command. (See also the [timeout] option.)
+
+A _key_ corresponds to pressing a single key on your keyboard, optionally while
+holding one or more _modifiers._ The following modifiers are recognized:
+
+- a: alt
+- c: control (also known as ctrl)
+- m: meta
+- s: shift
+
+(Which of the above you can actually use depends on your operating system.)
+
+If you’d like to know even more about the key notation, see
+[vim-like-key-notation].
+
+[timeout]: options.md#timeout
+[vim-like-key-notation]: https://github.com/lydell/vim-like-key-notation
+
+## Special keys
+
+Just like Vim, VimFx has a few “special keys:”
+
+- [`<force>`]
+- [`<late>`]
+
+No keyboard (or keyboard layout) can produce those (in practise). As a
+consequence, putting one of those “keys” in a shortcut would normally make it
+impossible to trigger. However, that is not the case for special keys.
+
+By putting a special key at the beginning of a shortcut, the shortcut will work
+exactly as it would without the special key, except that some behavior of the
+shortcut is changed (depending on the special key used). Special keys specify an
+_option_ for the shortcut rather than a key to press in order to activate the
+command.
+
+Each special key is described below.
+
+[`<force>`]: #force
+[`<late>`]: #late
+
+### `<force>`
+
+The `<force>` special key makes the shortcut in question available in text
+inputs.
+
+VimFx enters a kind of “automatic insert mode” when you focus a text input,
+allowing you to type text into it without triggering VimFx commands. The `esc`
+command, however, is still available, allowing you to blur the text input by
+pressing `<escape>`. The reason it is available is because the default shortcut
+is `<force><escape>`.
+
+Using `<force>` allows you to run other commands in text inputs as well. For
+example, you could use `<force><a-j>` and `<force><a-k>` to be able to select
+tab backward and forward regardless if you happen to be in a text input or not.
+
+### `late`
+
+The `<late>` special key makes the shortcut in question run _after_ the handling
+of key presses in the current page, allowing the current page to override it.
+
+Normally, all of VimFx’s shortcuts are triggered _before_ the current page gets
+the key presses. This makes the VimFx shortcuts work consistently regardless of
+what the current page happens to be up to.
+
+Sometimes, though, it is useful to let the page override a shortcut. For
+example, the [focus next/previous element] commands, use `<late>` in their
+default shorcuts: `<force><late><tab>` and `<force><late><s-tab>`, respectively.
+`<force>` is there so that you can press `<tab>` inside a text input to get to
+the next one; `<late>` lets the page offer tab completion instead, for example.
+
+`<late>` is also useful if you plan to use the arrow keys for VimFx’s scrolling
+commands, while still being able to move the focus in the custom menus some
+sites use.
+
+[focus next/previous element]: commands.md#focus-nextprevious-element

--- a/extension/lib/commands-frame.coffee
+++ b/extension/lib/commands-frame.coffee
@@ -274,7 +274,7 @@ commands.focus_text_input = ({ vim, storage, count = null }) ->
 commands.clear_inputs = ({ storage }) ->
   storage.inputs = null
 
-commands.move_focus = ({ vim, storage, direction, skip }) ->
+commands.move_focus = ({ vim, storage, direction }) ->
   if storage.inputs
     index = storage.inputs.indexOf(utils.getActiveElement(vim.content))
     if index == -1
@@ -285,21 +285,7 @@ commands.move_focus = ({ vim, storage, direction, skip }) ->
       utils.focusElement(nextInput, {select: true})
       return
 
-  return if skip
-
-  focusManager = Cc['@mozilla.org/focus-manager;1']
-    .getService(Ci.nsIFocusManager)
-  directionFlag =
-    if direction == -1
-      focusManager.MOVEFOCUS_BACKWARD
-    else
-      focusManager.MOVEFOCUS_FORWARD
-  focusManager.moveFocus(
-    null, # Use current window.
-    null, # Move relative to the currently focused element.
-    directionFlag,
-    focusManager.FLAG_BYKEY
-  )
+  utils.moveFocus(direction)
 
 commands.esc = ({ vim }) ->
   utils.blurActiveElement(vim.content)

--- a/extension/lib/commands.coffee
+++ b/extension/lib/commands.coffee
@@ -340,9 +340,12 @@ commands.focus_text_input = ({ vim, count }) ->
   vim._run('focus_text_input', {count})
 
 # Switch between text inputs or simulate `<tab>`.
-helper_move_focus = (direction, { vim, _skipMoveFocus }) ->
-  vim.markPageInteraction()
-  vim._run('move_focus', {direction, skip: _skipMoveFocus})
+helper_move_focus = (direction, { vim, isFrameEvent }) ->
+  if isFrameEvent
+    vim.markPageInteraction()
+    vim._run('move_focus', {direction})
+  else
+    utils.moveFocus(direction)
 
 commands.focus_next     = helper_move_focus.bind(null, +1)
 commands.focus_previous = helper_move_focus.bind(null, -1)

--- a/extension/lib/defaults.coffee
+++ b/extension/lib/defaults.coffee
@@ -79,8 +79,8 @@ shortcuts =
       '[':         'follow_previous'
       ']':         'follow_next'
       'gi':        'focus_text_input'
-      '<force><tab>':    'focus_next'
-      '<force><s-tab>':  'focus_previous'
+      '<force><late><tab>':   'focus_next'
+      '<force><late><s-tab>': 'focus_previous'
 
     'find':
       '/':         'find'

--- a/extension/lib/events-frame.coffee
+++ b/extension/lib/events-frame.coffee
@@ -58,6 +58,11 @@ class FrameEventManager
     @listen('keydown', (event) =>
       suppress = @vim.onInput(event)
 
+      # This also suppresses the 'keypress' and 'keyup' events. (Yes, in frame
+      # scripts, suppressing the 'keydown' events does seem to even suppress
+      # the 'keyup' event!)
+      utils.suppressEvent(event) if suppress
+
       # From this line on, the rest of the code in `addListeners` is more or
       # less devoted to autofocus prevention. When enabled, focus events that
       # occur before the user has interacted with page are prevented.
@@ -68,6 +73,13 @@ class FrameEventManager
       # `vim.markPageInteraction()` or not.
       @vim.markPageInteraction() unless suppress
     )
+
+    @listen('keydown', ((event) ->
+      suppress = messageManager.get('lateKeydown', {
+        defaultPrevented: event.defaultPrevented
+      })
+      utils.suppressEvent(event) if suppress
+    ), false)
 
     # Clicks are always counted as page interaction. Listen for 'mousedown'
     # instead of 'click' to mark the interaction as soon as possible.

--- a/extension/lib/events.coffee
+++ b/extension/lib/events.coffee
@@ -30,6 +30,7 @@ HELD_MODIFIERS_ATTRIBUTE = 'vimfx-held-modifiers'
 class UIEventManager
   constructor: (@vimfx, @window) ->
     @listen = utils.listen.bind(null, @window)
+    @listenOnce = utils.listenOnce.bind(null, @window)
 
     # This flag controls whether to suppress the various key events or not.
     @suppress = false
@@ -77,20 +78,17 @@ class UIEventManager
         vim = @vimfx.getCurrentVim(@window)
 
         if vim.isFrameEvent(event)
-          vim._listenOnce('onInput-frame', ({ @suppress }) =>
-            @setHeldModifiers(event)
+          vim._listenOnce('consumeKeyEvent', ({ focusType }) =>
+            @consumeKeyEvent(vim, event, focusType, { isFrameEvent: true })
+            return @suppress
           )
         else
-          @suppress = vim._onInput(event, utils.getFocusType(event))
-          @setHeldModifiers(event)
+          @consumeKeyEvent(vim, event, utils.getFocusType(event))
+          # This also suppresses the 'keypress' event.
           utils.suppressEvent(event) if @suppress
 
       catch error
         console.error(utils.formatError(error))
-    )
-
-    @listen('keypress', (event) =>
-      utils.suppressEvent(event) if @suppress
     )
 
     @listen('keyup', (event) =>
@@ -146,6 +144,43 @@ class UIEventManager
     module.onShutdown(=>
       @window.gBrowser.removeProgressListener(progressListener)
     )
+
+  consumeKeyEvent: (vim, event, focusType, options = {}) ->
+    match = vim._consumeKeyEvent(event, focusType)
+    switch
+      when not match
+        @suppress = null
+      when match.specialKeys['<late>']
+        @suppress = false
+        @consumeLateKeydown(vim, event, match, options)
+      else
+        @suppress = vim._onInput(match, options)
+    @setHeldModifiers(event)
+
+  consumeLateKeydown: (vim, event, match, options) ->
+    { isFrameEvent = false } = options
+
+    # The passed in `event` is the regular non-late browser UI keydown event.
+    # It is only used to set held keys. This is easier than sending an event
+    # subset from frame scripts.
+    listener = ({ defaultPrevented }) =>
+      @suppress =
+        if defaultPrevented
+          false
+        else
+          vim._onInput(match, options)
+      @setHeldModifiers(event)
+      return @suppress
+
+    if isFrameEvent
+      vim._listenOnce('lateKeydown', listener)
+    else
+      @listenOnce('keydown', ((lateEvent) =>
+        listener(lateEvent)
+        if @suppress
+          utils.suppressEvent(lateEvent)
+          @listenOnce('keyup', utils.suppressEvent, false)
+      ), false)
 
   setHeldModifiers: (event, { filterCurrentOnly = false } = {}) ->
     mainWindow = @window.document.documentElement

--- a/extension/lib/help.coffee
+++ b/extension/lib/help.coffee
@@ -97,10 +97,21 @@ createContent = (document, vimfx) ->
       for { command, enabledSequences } in category.commands
         commandContainer = $('command', categoryContainer)
         for sequence in enabledSequences
-          $('key-sequence', commandContainer, sequence)
+          keySequence = $('key-sequence', commandContainer)
+          [specialKeys, rest] = splitSequence(sequence, vimfx.SPECIAL_KEYS)
+          $('key-sequence-special-keys', keySequence, specialKeys)
+          $('key-sequence-rest', keySequence, rest)
         $('description', commandContainer, command.description())
 
   return content
+
+splitSequence = (sequence, specialKeys) ->
+  specialKeyEnds = specialKeys.map((key) ->
+    pos = sequence.lastIndexOf(key)
+    return if pos == -1 then 0 else pos + key.length
+  )
+  splitPos = Math.max(specialKeyEnds...)
+  return [sequence[0...splitPos], sequence[splitPos..]]
 
 module.exports = {
   injectHelp

--- a/extension/lib/modes.coffee
+++ b/extension/lib/modes.coffee
@@ -65,22 +65,15 @@ mode('normal', {
     { keyStr } = match
 
     autoInsertMode = (match.focus != null)
-    if match.type == 'none' or (autoInsertMode and not match.force)
+    if match.type == 'none' or
+       (autoInsertMode and not match.specialKeys['<force>'])
       if storage.returnTo
         vim.enterMode(storage.returnTo)
         storage.returnTo = null
       return false
 
     if match.type == 'full'
-      { command } = match
-      # Rely on the default `<tab>` behavior, since it allows web pages to
-      # provide tab completion, for example, inside text inputs.
-      args._skipMoveFocus = (
-        match.toplevel and
-        ((command.run == commands.focus_previous and keyStr == '<tab>') or
-         (command.run == commands.focus_next     and keyStr == '<s-tab>'))
-      )
-      command.run(args)
+      match.command.run(args)
 
       # If the command changed the mode, wait until coming back from that mode
       # before switching to `storage.returnTo` if any (see `onEnter` above).

--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -125,6 +125,21 @@ focusElement = (element, options = {}) ->
   focusManager.setFocus(element, focusManager.FLAG_BYKEY)
   element.select?() if options.select
 
+moveFocus = (direction) ->
+  focusManager = Cc['@mozilla.org/focus-manager;1']
+    .getService(Ci.nsIFocusManager)
+  directionFlag =
+    if direction == -1
+      focusManager.MOVEFOCUS_BACKWARD
+    else
+      focusManager.MOVEFOCUS_FORWARD
+  focusManager.moveFocus(
+    null, # Use current window.
+    null, # Move relative to the currently focused element.
+    directionFlag,
+    focusManager.FLAG_BYKEY
+  )
+
 getFocusType = (event) ->
   target = event.originalTarget
   return switch
@@ -141,17 +156,17 @@ getFocusType = (event) ->
 
 # Event helpers
 
-listen = (element, eventName, listener) ->
-  element.addEventListener(eventName, listener, USE_CAPTURE)
+listen = (element, eventName, listener, useCapture = true) ->
+  element.addEventListener(eventName, listener, useCapture)
   module.onShutdown(->
-    element.removeEventListener(eventName, listener, USE_CAPTURE)
+    element.removeEventListener(eventName, listener, useCapture)
   )
 
-listenOnce = (element, eventName, listener) ->
+listenOnce = (element, eventName, listener, useCapture = true) ->
   fn = (event) ->
     listener(event)
-    element.removeEventListener(eventName, fn, USE_CAPTURE)
-  listen(element, eventName, fn)
+    element.removeEventListener(eventName, fn, useCapture)
+  listen(element, eventName, fn, useCapture)
 
 suppressEvent = (event) ->
   event.preventDefault()
@@ -302,6 +317,7 @@ module.exports = {
   blurActiveElement
   blurActiveBrowserElement
   focusElement
+  moveFocus
   getFocusType
 
   listen

--- a/extension/lib/vim-frame.coffee
+++ b/extension/lib/vim-frame.coffee
@@ -56,13 +56,8 @@ class VimFrame
     })
 
   onInput: (event) ->
-    eventSubset = {}
-    for key in ['key', 'code', 'altKey', 'ctrlKey', 'metaKey', 'shiftKey']
-      eventSubset[key] = event[key]
-    args = [eventSubset, utils.getFocusType(event), {isFrameEvent: true}]
-    suppress = messageManager.get('vimMethodSync', {method: '_onInput', args})
-    utils.suppressEvent(event) if suppress
-    messageManager.send('onInput-frame', { suppress })
+    focusType = utils.getFocusType(event)
+    suppress = messageManager.get('consumeKeyEvent', {focusType})
     return suppress
 
   notify: (args...) ->

--- a/extension/lib/vim.coffee
+++ b/extension/lib/vim.coffee
@@ -92,9 +92,10 @@ class Vim
     @_send('modeChange', {mode})
     return true
 
-  _onInput: (event, focusType, { isFrameEvent = false } = {}) ->
-    match = @_parent.consumeKeyEvent(event, this, focusType)
-    return null unless match
+  _consumeKeyEvent: (event, focusType) ->
+    return @_parent.consumeKeyEvent(event, this, focusType)
+
+  _onInput: (match, { isFrameEvent = false } = {}) ->
     suppress = @_call('onInput', {isFrameEvent, count: match.count}, match)
     return suppress
 

--- a/extension/locale/de/vimfx.properties
+++ b/extension/locale/de/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Unbekannter Modifikator: %S. Benutze nur a, c, m und 
 error.duplicate_modifier=%S: Doppelter Modifikator: %S.
 error.disallowed_modifier=%S: Man kann den Umschalt-Modifikator für diese Taste nicht festlegen. Schreibe z. B. <c-A> anstelle von <c-s-a>.
 error.overridden_by=%S: Überschrieben durch: %S
-error.illegal_force_key=%S: %S ist nur als Präfix erlaubt
+error.illegal_special_key=%S: %S ist nur als Präfix erlaubt

--- a/extension/locale/el-GR/vimfx.properties
+++ b/extension/locale/el-GR/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Unknown modifier: %S. Use only a, c, m and s.
 error.duplicate_modifier=%S: Duplicate modifier: %S.
 error.disallowed_modifier=%S: You cannot specifiy the Shift modifier for this key. For example, write <c-A> instead of <c-s-a>.
 error.overridden_by=%S: Overridden by: %S
-error.illegal_force_key=%S: %S is only allowed as a prefix.
+error.illegal_special_key=%S: %S is only allowed as a prefix.

--- a/extension/locale/en-US/vimfx.properties
+++ b/extension/locale/en-US/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Unknown modifier: %S. Use only a, c, m and s.
 error.duplicate_modifier=%S: Duplicate modifier: %S.
 error.disallowed_modifier=%S: You cannot specifiy the Shift modifier for this key. For example, write <c-A> instead of <c-s-a>.
 error.overridden_by=%S: Overridden by: %S
-error.illegal_force_key=%S: %S is only allowed as a prefix.
+error.illegal_special_key=%S: %S is only allowed as a prefix.

--- a/extension/locale/fr/vimfx.properties
+++ b/extension/locale/fr/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Modificateur inconnu: %S. Utilisez seulement a, c, m 
 error.duplicate_modifier=%S: Modificateur dupliqué: %S.
 error.disallowed_modifier=%S: Vous ne pouvez pas utiliser le modificateur « Maj. » pour cette touche. Exemple: écrivez « <c-A> » au lieu de « <c-s-a> ».
 error.overridden_by=%S: Surchargé par: %S
-error.illegal_force_key=%S: %S est seulement autorisé comme préfixe.
+error.illegal_special_key=%S: %S est seulement autorisé comme préfixe.

--- a/extension/locale/hu/vimfx.properties
+++ b/extension/locale/hu/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Unknown modifier: %S. Use only a, c, m and s.
 error.duplicate_modifier=%S: Duplicate modifier: %S.
 error.disallowed_modifier=%S: You cannot specifiy the Shift modifier for this key. For example, write <c-A> instead of <c-s-a>.
 error.overridden_by=%S: Overridden by: %S
-error.illegal_force_key=%S: %S is only allowed as a prefix.
+error.illegal_special_key=%S: %S is only allowed as a prefix.

--- a/extension/locale/id/vimfx.properties
+++ b/extension/locale/id/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Modifier tidak dikenali: %S. Gunakan hanya a, c, m da
 error.duplicate_modifier=%S: Modifier sudah dipakai: %S.
 error.disallowed_modifier=%S: Anda tidak dapat menggunakan key modifier Shift untuk key ini. Sebagai contoh, tuliskan <c-A> daripada <c-s-a>.
 error.overridden_by=%S: Diabaikan karena: %S
-error.illegal_force_key=%S: %S hanya diperbolehkan sebagai prefiks.
+error.illegal_special_key=%S: %S hanya diperbolehkan sebagai prefiks.

--- a/extension/locale/it/vimfx.properties
+++ b/extension/locale/it/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Unknown modifier: %S. Use only a, c, m and s.
 error.duplicate_modifier=%S: Duplicate modifier: %S.
 error.disallowed_modifier=%S: You cannot specifiy the Shift modifier for this key. For example, write <c-A> instead of <c-s-a>.
 error.overridden_by=%S: Overridden by: %S
-error.illegal_force_key=%S: %S is only allowed as a prefix.
+error.illegal_special_key=%S: %S is only allowed as a prefix.

--- a/extension/locale/ja/vimfx.properties
+++ b/extension/locale/ja/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: 不明な装飾キー: %S. a, c, m, s のみが使用
 error.duplicate_modifier=%S: 装飾キーが重複: %S。
 error.disallowed_modifier=%S: このキーはシフトで装飾できません。例えば <c-s-a> の代わりに <c-A> と書いてください。
 error.overridden_by=%S: %S が上書きしています。
-error.illegal_force_key=%S: %S は前置のみ可能です。
+error.illegal_special_key=%S: %S は前置のみ可能です。

--- a/extension/locale/nl/vimfx.properties
+++ b/extension/locale/nl/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Ongeldig commando: %S. Gebruik alleen a, c, m en s.
 error.duplicate_modifier=%S: Deze combinatie is al in gebruik: %S.
 error.disallowed_modifier=%S: Deze toets kan niet samen met shift gebruikt worden. Gebruik bijvoorbeeld <c-A> in plaats van <c-s-a>.
 error.overridden_by=%S: Overschreven door: %S
-error.illegal_force_key=%S: %S is alleen toegestaan als prefix.
+error.illegal_special_key=%S: %S is alleen toegestaan als prefix.

--- a/extension/locale/pl/vimfx.properties
+++ b/extension/locale/pl/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Unknown modifier: %S. Use only a, c, m and s.
 error.duplicate_modifier=%S: Duplicate modifier: %S.
 error.disallowed_modifier=%S: You cannot specifiy the Shift modifier for this key. For example, write <c-A> instead of <c-s-a>.
 error.overridden_by=%S: Overridden by: %S
-error.illegal_force_key=%S: %S is only allowed as a prefix.
+error.illegal_special_key=%S: %S is only allowed as a prefix.

--- a/extension/locale/pt-BR/vimfx.properties
+++ b/extension/locale/pt-BR/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Modificador desconhecido: %S. Use somente a, c, m e s
 error.duplicate_modifier=%S: Modificador duplicado: %S.
 error.disallowed_modifier=%S: Você não pode usar o modificador Shift para esta tecla. Por exemplo, escreva <c-A> ao invés de <c-s-a>.
 error.overridden_by=%S: Sobrescrito por: %S
-error.illegal_force_key=%S: %S somente é permitido como um prefixo.
+error.illegal_special_key=%S: %S somente é permitido como um prefixo.

--- a/extension/locale/ru/vimfx.properties
+++ b/extension/locale/ru/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Неизвестный модификатор: %S. И
 error.duplicate_modifier=%S: Дублирующийся модификатор: %S.
 error.disallowed_modifier=%S: Нельзя указать модификатор Shift для этой клавиши. Например, пишите <c-A> вместо <c-s-a>.
 error.overridden_by=%S: Overridden by: %S
-error.illegal_force_key=%S: %S is only allowed as a prefix.
+error.illegal_special_key=%S: %S is only allowed as a prefix.

--- a/extension/locale/sv-SE/vimfx.properties
+++ b/extension/locale/sv-SE/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: Okänd modifierare: %S. Använd endast a, c, m och s.
 error.duplicate_modifier=%S: Upprepad modifierare: %S.
 error.disallowed_modifier=%S: Du kan inte ange Skift-modifieraren för denna tangent. Till exempel, skriv <c-A> istället för <c-s-a>.
 error.overridden_by=%S: Överskriven av: %S
-error.illegal_force_key=%S: %S tillåts endast som prefix.
+error.illegal_special_key=%S: %S tillåts endast som prefix.

--- a/extension/locale/zh-CN/vimfx.properties
+++ b/extension/locale/zh-CN/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: 未知修饰键: %S. 只能使用 a, c, m 和 s.
 error.duplicate_modifier=%S: 重复的修饰键: %S.
 error.disallowed_modifier=%S: 您不能为这个快捷键指定 Shift 修饰键。比如用 <c-A> 代替 <c-s-a> 。
 error.overridden_by=%S: 被 %S 覆盖
-error.illegal_force_key=%S: %S 只允许作为前缀
+error.illegal_special_key=%S: %S 只允许作为前缀

--- a/extension/locale/zh-TW/vimfx.properties
+++ b/extension/locale/zh-TW/vimfx.properties
@@ -124,4 +124,4 @@ error.unknown_modifier=%S: 未知的修飾鍵: %S.只能使用 a, c, m 或 s.
 error.duplicate_modifier=%S: 重複的修飾鍵: %S.
 error.disallowed_modifier=%S: 您不能為這個快速鍵指定 Shift 修飾鍵。例如：使用　<c-A> 取代 <c-s-a>。
 error.overridden_by=%S: 被以下設定覆寫: %S
-error.illegal_force_key=%S: %S 只能用在前餟。
+error.illegal_special_key=%S: %S 只能用在前餟。

--- a/extension/skin/style.css
+++ b/extension/skin/style.css
@@ -216,6 +216,16 @@ toolbarpaletteitem[place="palette"] > #VimFxButton {
         margin-right: 0.7ch;
       }
 
+      #VimFxHelpDialogContainer .key-sequence-special-keys {
+        /* The special keys are not helpful in the help dialog. If somebody
+         * disagrees, they can simply re-show them with custom CSS. */
+        display: none;
+      }
+
+      #VimFxHelpDialogContainer .key-sequence-rest {
+        display: inline;
+      }
+
     #VimFxHelpDialogContainer .description {
       float: right;
       /* The space to the left should be wide enough to fit `<c-w>`. */


### PR DESCRIPTION
By including the special key `<late>` in a shortcut it is run _after_ web page
event listeners, allowing them to override the VimFx shortcut. This is useful
when binding to `<tab>` and the arrow keys.