### PR TITLE
Rework `gi` handling of `<tab>`

### DIFF
--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -116,18 +116,13 @@ autofocus prevention, and type `gi` when you wish you hadn’t.
 that `gi` and `1gi` are different: The latter _always_ focuses the first input
 of the page, regradless of which input you used last.
 
+After having focused a text input using `gi`, `<tab>` and `<s-tab>` will _only
+cycle between text inputs,_ instead of moving the focus between _all_ focusable
+elements as they usually do. (See also the [`focus_previous_key` and
+`focus_next_key`] advanced options.)
+
 [prevented autofocus]: options.md#prevent-autofocus
-
-
-## Focus next/previous element
-
-The default shorcuts are `<tab>` and `<s-tab>`, respectively (to be precise,
-they also include [special keys]). They work just like `<tab>` works normally,
-except that if you focused a text input using the `gi` command they will only
-switch between text inputs on thee page, as opposed to between all focusable
-elements (such as links, buttons and checkboxes) as they do otherwise.
-
-[special keys]: shortcuts.md#special-keys
+[`focus_previous_key` and `focus_next_key`]: options.md#focus_previous_key-and-focus_next_key
 
 
 ## The `f` commands

--- a/documentation/options.md
+++ b/documentation/options.md
@@ -235,6 +235,14 @@ an “activatable” element (link or button) is focused.
 Keys that should not trigger VimFx commands but be sent through to the page if
 an “adjustable” element (form control or video player) is focused.
 
+### `focus_previous_key` and `focus_next_key`
+
+The default values are `<s-tab` and `<tab>`, respectively. Those keys are
+specially handled after focusing a text input using [`gi`]. To disable this
+special handling, set the prefs to the empty string.
+
+[`gi`]: commands.md#gi-1
+
 
 ## Special options
 

--- a/documentation/questions-and-answers.md
+++ b/documentation/questions-and-answers.md
@@ -13,16 +13,6 @@ the beginning, and your new shortcut should work fine.
 
 [`<force>`]: shortcuts.md#force
 
-## What does `<force><late><tab>` mean?
-
-- `<force>`: The shortcut works even in text inputs.
-- `<late>`: The page can override it.
-- `<tab>`: Press the Tab key to trigger it.
-
-Need more explaination? Read about [special keys].
-
-[special keys]: shortcuts.md#special-keys
-
 ## Will VimFx provide advanced Find features?
 
 One VimFx’s key feauters is to embrace standard Firefox features. As long as

--- a/documentation/shortcuts.md
+++ b/documentation/shortcuts.md
@@ -99,13 +99,5 @@ the key presses. This makes the VimFx shortcuts work consistently regardless of
 what the current page happens to be up to.
 
 Sometimes, though, it is useful to let the page override a shortcut. For
-example, the [focus next/previous element] commands, use `<late>` in their
-default shorcuts: `<force><late><tab>` and `<force><late><s-tab>`, respectively.
-`<force>` is there so that you can press `<tab>` inside a text input to get to
-the next one; `<late>` lets the page offer tab completion instead, for example.
-
-`<late>` is also useful if you plan to use the arrow keys for VimFx’s scrolling
-commands, while still being able to move the focus in the custom menus some
-sites use.
-
-[focus next/previous element]: commands.md#focus-nextprevious-element
+example, if you plan to use the arrow keys for VimFx’s scrolling commands, while
+still being able to move the focus in the custom menus some sites use.

--- a/extension/lib/commands-frame.coffee
+++ b/extension/lib/commands-frame.coffee
@@ -294,20 +294,19 @@ commands.clear_inputs = ({vim}) ->
   vim.state.inputs = null
 
 commands.move_focus = ({vim, direction}) ->
-  if vim.state.inputs
-    index = vim.state.inputs.indexOf(utils.getActiveElement(vim.content))
-    # If there’s only one input, `<tab>` would cycle to itself, making it feel
-    # like `<tab>` was not working. Then it’s better to let `<tab>` work as it
-    # usually does.
-    if index == -1 or vim.state.inputs.length <= 1
-      vim.state.inputs = null
-    else
-      {inputs} = vim.state
-      nextInput = inputs[(index + direction) %% inputs.length]
-      utils.focusElement(nextInput, {select: true})
-      return
-
-  utils.moveFocus(direction)
+  return false unless vim.state.inputs
+  index = vim.state.inputs.indexOf(utils.getActiveElement(vim.content))
+  # If there’s only one input, `<tab>` would cycle to itself, making it feel
+  # like `<tab>` was not working. Then it’s better to let `<tab>` work as it
+  # usually does.
+  if index == -1 or vim.state.inputs.length <= 1
+    vim.state.inputs = null
+    return false
+  else
+    {inputs} = vim.state
+    nextInput = inputs[(index + direction) %% inputs.length]
+    utils.focusElement(nextInput, {select: true})
+    return true
 
 commands.esc = (args) ->
   commands.blur_active_element(args)

--- a/extension/lib/commands-frame.coffee
+++ b/extension/lib/commands-frame.coffee
@@ -87,9 +87,9 @@ combine = (hrefs, element, wrapper) ->
       hrefs[href] = wrapper
   return wrapper
 
-commands.follow = ({vim, storage}) ->
+commands.follow = ({vim}) ->
   hrefs = {}
-  storage.markerElements = []
+  vim.state.markerElements = []
   filter = (element, getElementShape) ->
     document = element.ownerDocument
     isXUL = (document instanceof XULDocument)
@@ -154,20 +154,20 @@ commands.follow = ({vim, storage}) ->
         type = 'clickable'
     return unless type
     return unless shape = getElementShape(element)
-    length = storage.markerElements.push(element)
+    length = vim.state.markerElements.push(element)
     return combine(
       hrefs, element, {elementIndex: length - 1, shape, semantic, type}
     )
 
   return hints.getMarkableElementsAndViewport(vim.content, filter)
 
-commands.follow_in_tab = ({vim, storage}) ->
+commands.follow_in_tab = ({vim}) ->
   hrefs = {}
-  storage.markerElements = []
+  vim.state.markerElements = []
   filter = (element, getElementShape) ->
     return unless isProperLink(element)
     return unless shape = getElementShape(element)
-    length = storage.markerElements.push(element)
+    length = vim.state.markerElements.push(element)
     return combine(
       hrefs, element,
       {elementIndex: length - 1, shape, semantic: true, type: 'link'}
@@ -175,9 +175,9 @@ commands.follow_in_tab = ({vim, storage}) ->
 
   return hints.getMarkableElementsAndViewport(vim.content, filter)
 
-commands.follow_copy = ({vim, storage}) ->
+commands.follow_copy = ({vim}) ->
   hrefs = {}
-  storage.markerElements = []
+  vim.state.markerElements = []
   filter = (element, getElementShape) ->
     type = switch
       when isProperLink(element)      then 'link'
@@ -185,15 +185,15 @@ commands.follow_copy = ({vim, storage}) ->
       when isContentEditable(element) then 'contenteditable'
     return unless type
     return unless shape = getElementShape(element)
-    length = storage.markerElements.push(element)
+    length = vim.state.markerElements.push(element)
     return combine(
       hrefs, element, {elementIndex: length - 1, shape, semantic: true, type}
     )
 
   return hints.getMarkableElementsAndViewport(vim.content, filter)
 
-commands.follow_focus = ({vim, storage}) ->
-  storage.markerElements = []
+commands.follow_focus = ({vim}) ->
+  vim.state.markerElements = []
   filter = (element, getElementShape) ->
     type = switch
       when element.tabIndex > -1
@@ -203,18 +203,18 @@ commands.follow_focus = ({vim, storage}) ->
         'scrollable'
     return unless type
     return unless shape = getElementShape(element)
-    length = storage.markerElements.push(element)
+    length = vim.state.markerElements.push(element)
     return {elementIndex: length - 1, shape, semantic: true, type}
 
   return hints.getMarkableElementsAndViewport(vim.content, filter)
 
-commands.focus_marker_element = ({storage, elementIndex, options}) ->
-  element = storage.markerElements[elementIndex]
+commands.focus_marker_element = ({vim, elementIndex, options}) ->
+  element = vim.state.markerElements[elementIndex]
   utils.focusElement(element, options)
 
 commands.click_marker_element = (args) ->
-  {vim, storage, elementIndex, preventTargetBlank, type} = args
-  element = storage.markerElements[elementIndex]
+  {vim, elementIndex, preventTargetBlank, type} = args
+  element = vim.state.markerElements[elementIndex]
   if element.target == '_blank' and preventTargetBlank
     targetReset = element.target
     element.target = ''
@@ -224,8 +224,8 @@ commands.click_marker_element = (args) ->
     utils.simulateClick(element)
   element.target = targetReset if targetReset
 
-commands.copy_marker_element = ({storage, elementIndex, property}) ->
-  element = storage.markerElements[elementIndex]
+commands.copy_marker_element = ({vim, elementIndex, property}) ->
+  element = vim.state.markerElements[elementIndex]
   utils.writeToClipboard(element[property])
 
 commands.follow_pattern = ({vim, type, options}) ->
@@ -270,7 +270,7 @@ commands.follow_pattern = ({vim, type, options}) ->
 
   utils.simulateClick(matchingLink) if matchingLink
 
-commands.focus_text_input = ({vim, storage, count = null}) ->
+commands.focus_text_input = ({vim, count = null}) ->
   {lastFocusedTextInput} = vim.state
   inputs = Array.filter(
     utils.querySelectorAllDeep(vim.content, 'input, textarea'), (element) ->
@@ -288,21 +288,21 @@ commands.focus_text_input = ({vim, storage, count = null}) ->
         1
   index = Math.min(count, inputs.length) - 1
   utils.focusElement(inputs[index], {select: true})
-  storage.inputs = inputs
+  vim.state.inputs = inputs
 
-commands.clear_inputs = ({storage}) ->
-  storage.inputs = null
+commands.clear_inputs = ({vim}) ->
+  vim.state.inputs = null
 
-commands.move_focus = ({vim, storage, direction}) ->
-  if storage.inputs
-    index = storage.inputs.indexOf(utils.getActiveElement(vim.content))
+commands.move_focus = ({vim, direction}) ->
+  if vim.state.inputs
+    index = vim.state.inputs.indexOf(utils.getActiveElement(vim.content))
     # If there’s only one input, `<tab>` would cycle to itself, making it feel
     # like `<tab>` was not working. Then it’s better to let `<tab>` work as it
     # usually does.
-    if index == -1 or storage.inputs.length <= 1
-      storage.inputs = null
+    if index == -1 or vim.state.inputs.length <= 1
+      vim.state.inputs = null
     else
-      {inputs} = storage
+      {inputs} = vim.state
       nextInput = inputs[(index + direction) %% inputs.length]
       utils.focusElement(nextInput, {select: true})
       return

--- a/extension/lib/commands.coffee
+++ b/extension/lib/commands.coffee
@@ -384,17 +384,6 @@ commands.focus_text_input = ({vim, count}) ->
   vim.markPageInteraction()
   vim._run('focus_text_input', {count})
 
-# Switch between text inputs or simulate `<tab>`.
-helper_move_focus = (direction, {vim, uiEvent}) ->
-  if uiEvent
-    utils.moveFocus(direction)
-  else
-    vim.markPageInteraction()
-    vim._run('move_focus', {direction})
-
-commands.focus_next     = helper_move_focus.bind(null, +1)
-commands.focus_previous = helper_move_focus.bind(null, -1)
-
 
 
 findStorage = {lastSearchString: ''}

--- a/extension/lib/defaults.coffee
+++ b/extension/lib/defaults.coffee
@@ -79,8 +79,6 @@ shortcuts =
       '[':         'follow_previous'
       ']':         'follow_next'
       'gi':        'focus_text_input'
-      '<force><late><tab>':   'focus_next'
-      '<force><late><s-tab>': 'focus_previous'
 
     'find':
       '/':         'find'
@@ -136,6 +134,8 @@ advanced_options =
   'activatable_element_keys':           '<enter>'
   'adjustable_element_keys':            '<arrowup>  <arrowdown>  <arrowleft>
                                          <arrowright>  <space>  <enter>'
+  'focus_previous_key':                 '<s-tab>'
+  'focus_next_key':                     '<tab>'
   'options.key.quote':                  '<c-q>'
   'options.key.insert_default':         '<c-d>'
   'options.key.reset_default':          '<c-r>'

--- a/extension/lib/main-frame.coffee
+++ b/extension/lib/main-frame.coffee
@@ -27,12 +27,11 @@ VimFrame          = require('./vim-frame')
 module.exports = ->
   {content} = FRAME_SCRIPT_ENVIRONMENT
   vim = new VimFrame(content)
-  storage = {}
 
   eventManager = new FrameEventManager(vim)
   eventManager.addListeners()
 
   messageManager.listen('runCommand', ({name, data}, {callback}) ->
-    result = commands[name](Object.assign({vim, storage}, data))
+    result = commands[name](Object.assign({vim}, data))
     messageManager.send(callback, result) if callback?
   )

--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -128,21 +128,6 @@ focusElement = (element, options = {}) ->
   focusManager.setFocus(element, focusManager.FLAG_BYKEY)
   element.select?() if options.select
 
-moveFocus = (direction) ->
-  focusManager = Cc['@mozilla.org/focus-manager;1']
-    .getService(Ci.nsIFocusManager)
-  directionFlag =
-    if direction == -1
-      focusManager.MOVEFOCUS_BACKWARD
-    else
-      focusManager.MOVEFOCUS_FORWARD
-  focusManager.moveFocus(
-    null, # Use current window.
-    null, # Move relative to the currently focused element.
-    directionFlag,
-    focusManager.FLAG_BYKEY
-  )
-
 getFocusType = (event) ->
   target = event.originalTarget
   return switch
@@ -336,7 +321,6 @@ module.exports = {
   blurActiveElement
   blurActiveBrowserElement
   focusElement
-  moveFocus
   getFocusType
 
   listen

--- a/extension/lib/vim-frame.coffee
+++ b/extension/lib/vim-frame.coffee
@@ -47,6 +47,8 @@ class VimFrame
       lastFocusedTextInput: null
       shouldRefocus:        false
       scrollableElements:   new ScrollableElements(@content)
+      markerElements:       []
+      inputs:               null
 
   options: (prefs) -> messageManager.get('options', {prefs})
 

--- a/extension/lib/vim.coffee
+++ b/extension/lib/vim.coffee
@@ -115,15 +115,6 @@ class Vim
     return @_parent.consumeKeyEvent(event, this, focusType)
 
   _onInput: (match, uiEvent = false) ->
-    # In the location bar, `<tab>` is used to cycle between autocomplete
-    # results. In the dev tools, `<tab>` autocompletes what you’re typing. The
-    # only way to preverve this important behavior seems to be special casing.
-    {focus_previous, focus_next} = @_parent.modes.normal.commands
-    if uiEvent and
-      ((match.command == focus_previous and match.keyStr == '<s-tab>') or
-       (match.command == focus_next     and match.keyStr == '<tab>'))
-      return false
-
     suppress = @_call('onInput', {uiEvent, count: match.count}, match)
     return suppress
 

--- a/extension/locale/de/vimfx.properties
+++ b/extension/locale/de/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Element fokussieren oder auswählen
 mode.normal.follow_previous=Zur vorherigen Seite springen
 mode.normal.follow_next=Zur nächsten Seite springen
 mode.normal.focus_text_input=Zuletzt fokussierte oder erste Texteingabe fokussieren
-mode.normal.focus_next=Nächstes Element fokussieren
-mode.normal.focus_previous=Vorheriges Element fokussieren
 
 category.find=Suchen
 mode.normal.find=Suchmodus aktivieren

--- a/extension/locale/el-GR/vimfx.properties
+++ b/extension/locale/el-GR/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Focus/select element
 mode.normal.follow_previous=Πήγαινε στην προηγούμενη σελίδα
 mode.normal.follow_next=Πήγαινε στην επόμενη σελίδα
 mode.normal.focus_text_input=Focus last focused or first text input
-mode.normal.focus_next=Focus next element
-mode.normal.focus_previous=Focus previous element
 
 category.find=Find
 mode.normal.find=Είσοδος σε λειτουργία Εύρεσης (Find mode)

--- a/extension/locale/en-US/vimfx.properties
+++ b/extension/locale/en-US/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Focus/select element
 mode.normal.follow_previous=Go to the previous page
 mode.normal.follow_next=Go to the next page
 mode.normal.focus_text_input=Focus last focused or first text input
-mode.normal.focus_next=Focus next element
-mode.normal.focus_previous=Focus previous element
 
 category.find=Find
 mode.normal.find=Enter Find mode

--- a/extension/locale/fr/vimfx.properties
+++ b/extension/locale/fr/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Focaliser l'élément
 mode.normal.follow_previous=Aller à la page précédente
 mode.normal.follow_next=Aller à la page suivante
 mode.normal.focus_text_input=Focaliser la dernière entrée de texte à avoir été focalisé ou la première
-mode.normal.focus_next=Focaliser l'élément suivant
-mode.normal.focus_previous=Focaliser l'élément précédent
 
 category.find=Recherche
 mode.normal.find=Rechercher dans la page

--- a/extension/locale/hu/vimfx.properties
+++ b/extension/locale/hu/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Focus/select element
 mode.normal.follow_previous=Go to previous page
 mode.normal.follow_next=Go to next page
 mode.normal.focus_text_input=Focus last focused or first text input
-mode.normal.focus_next=Focus next element
-mode.normal.focus_previous=Focus previous element
 
 category.find=Find
 mode.normal.find=Keresési módba lépés

--- a/extension/locale/id/vimfx.properties
+++ b/extension/locale/id/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Fokus/pilih element
 mode.normal.follow_previous=Menuju halaman sebelum
 mode.normal.follow_next=Menuju halaman berikut
 mode.normal.focus_text_input=Fokus pada fokus terakhir atau masukan teks pertama
-mode.normal.focus_next=Fokus pada element berikut
-mode.normal.focus_previous=Fokus pada element sebelum
 
 category.find=Cari
 mode.normal.find=Masuk mode Cari

--- a/extension/locale/it/vimfx.properties
+++ b/extension/locale/it/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Attiva/seleziona elemento
 mode.normal.follow_previous=Vai alla pagina precedente
 mode.normal.follow_next=Vai alla prossima pagina
 mode.normal.focus_text_input=Seleziona l'ultimo input selezionato o il primo
-mode.normal.focus_next=Seleziona l'elemento successivo
-mode.normal.focus_previous=Seleziona l'elemento precedente
 
 category.find=Trova
 mode.normal.find=Entra nella modalità ricerca

--- a/extension/locale/ja/vimfx.properties
+++ b/extension/locale/ja/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=要素にフォーカス/選択
 mode.normal.follow_previous=前のページに移動
 mode.normal.follow_next=次のページに移動
 mode.normal.focus_text_input=最後にフォーカスしたテキスト入力または最初のテキスト入力にフォーカス
-mode.normal.focus_next=次の要素にフォーカス
-mode.normal.focus_previous=前の要素にフォーカス
 
 category.find=検索
 mode.normal.find=ページ内検索モードに入る

--- a/extension/locale/nl/vimfx.properties
+++ b/extension/locale/nl/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Focus/selecteer element
 mode.normal.follow_previous=Ga naar vorige pagina
 mode.normal.follow_next=Ga naar volgende pagina
 mode.normal.focus_text_input=Focus laatst gefocuste or eerste invoerveld
-mode.normal.focus_next=Focus volgende element
-mode.normal.focus_previous=Focus volgende element
 
 category.find=Zoeken
 mode.normal.find=Zoeken

--- a/extension/locale/pl/vimfx.properties
+++ b/extension/locale/pl/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Focus/select element
 mode.normal.follow_previous=Idź do poprzedniej strony
 mode.normal.follow_next=Idź do następnej strony
 mode.normal.focus_text_input=Focus last focused or first text input
-mode.normal.focus_next=Focus next element
-mode.normal.focus_previous=Focus previous element
 
 category.find=Find
 mode.normal.find=Znajdź

--- a/extension/locale/pt-BR/vimfx.properties
+++ b/extension/locale/pt-BR/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Focar/selecionar elemento
 mode.normal.follow_previous=Ir para página anterior
 mode.normal.follow_next=Ir para próxima página
 mode.normal.focus_text_input=Focar no último focado ou primeiro campo texto
-mode.normal.focus_next=Focar no próximo elemento
-mode.normal.focus_previous=Focar no elemento anterior
 
 category.find=Localizar
 mode.normal.find=Entrar no modo de Busca

--- a/extension/locale/ru/vimfx.properties
+++ b/extension/locale/ru/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Фокус на/выбрать элемент
 mode.normal.follow_previous=Перейти к предыдущей странице
 mode.normal.follow_next=Перейти к следующей странице
 mode.normal.focus_text_input=Вернуть фокус на поле вводa
-mode.normal.focus_next=Фокус на следующий элемент
-mode.normal.focus_previous=Фокус на предыдущий элемент
 
 category.find=Поиск
 mode.normal.find=Режим поиска

--- a/extension/locale/sv-SE/vimfx.properties
+++ b/extension/locale/sv-SE/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=Fokusera/markera element
 mode.normal.follow_previous=Gå till föregående sida
 mode.normal.follow_next=Gå till nästa sida
 mode.normal.focus_text_input=Fokusera senast fokuserade eller den första textrutan
-mode.normal.focus_next=Fokusera nästa element
-mode.normal.focus_previous=Fokusera föregående element
 
 category.find=Sök
 mode.normal.find=Gå till Sökläge

--- a/extension/locale/zh-CN/vimfx.properties
+++ b/extension/locale/zh-CN/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=聚焦/选中元素
 mode.normal.follow_previous=打开上一页
 mode.normal.follow_next=打开下一页
 mode.normal.focus_text_input=聚焦最后聚焦过的或第一个输入框
-mode.normal.focus_next=聚焦下一个元素
-mode.normal.focus_previous=聚焦上一个元素
 
 category.find=查找
 mode.normal.find=进入查找模式

--- a/extension/locale/zh-TW/vimfx.properties
+++ b/extension/locale/zh-TW/vimfx.properties
@@ -63,8 +63,6 @@ mode.normal.follow_focus=移動焦點/選取元素
 mode.normal.follow_previous=上一頁
 mode.normal.follow_next=下一頁
 mode.normal.focus_text_input=移至最後聚焦過或第一個輸入欄位
-mode.normal.focus_next=移至下一個焦點
-mode.normal.focus_previous=移至上一個焦點
 
 category.find=搜尋
 mode.normal.find=進入搜尋模式


### PR DESCRIPTION
The "Focus previous/next element" commands turned out to be too intrusive. This PR removes them, and instead handles `<tab>` and `<s-tab>` in a hard-coded fashion:

- _Only_ in web page content.
- _Only_ if in "`gi` mode".
- Always "late", taking `event.defaultPrevented` into account.
- Not if `<tab>` executed a command.