### PR TITLE
Rework how notifications are shown

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -15,6 +15,7 @@ License"](GNU%20Free%20Documentation%20License).
 - [Commands](commands.md)
 - [Shortcuts](shortcuts.md)
 - [Button](button.md)
+- [Notifications](notifications.md)
 - [Styling](styling.md)
 - [Handy standard Firefox features](handy-standard-firefox-features.md)
 - [Questions & Answers](questions-and-answers.md)

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -231,6 +231,23 @@ vimfx.on('locationChange', ({vim, location}) => {
 })
 ```
 
+#### The `notification` and `hideNotification` events
+
+The `notification` event occurs when `vim.notify(message)` is called, and means
+that `message` should be displayed to the user.
+
+The `hideNotification` event occurs when the `vim.hideNotification()` is called,
+and means that the current notification is requested to be hidden.
+
+The data passed to listeners is an object with the following properties:
+
+- vim: The current [vim object].
+- message: The message that should be notified. Only for the `notification`
+  event.
+
+Both of these events are emitted even if the [`notifications_enabled`] option is
+disabled, allowing you to display notifications in any way you want.
+
 #### The `modeChange` event
 
 Occurs whenever the current mode in any tab changes. The initial entering of the
@@ -494,9 +511,9 @@ A `vim` object has the following properties:
 - isUIEvent(event): `Function`. Returns `true` if `event` occurred in the
   browser UI, and `false` otherwise (if it occurred in web page content).
 
-- notify(title, options = {}): `Function`. Display a notification with the title
-  `title` (a `String`). If you need more text than a title, use `options.body`.
-  See [`Notification`] for more information.
+- notify(message): `Function`. Display a notification with the text `message`.
+
+- hideNotification(): `Function`. Hide the current notification (if any).
 
 - markPageInteraction(): `Function`. Marks that the user has interacted with the
   page. After that [autofocus prevention] is not done anymore. Commands
@@ -563,6 +580,7 @@ backwards compatibility will be a priority and won’t be broken until VimFx
 [autofocus prevention]: options.md#prevent-autofocus
 [`activatable_element_keys`]: options.md#activatable_element_keys
 [`adjustable_element_keys`]: options.md#adjustable_element_keys
+[`notifications_enabled`]: options.md#notifications_enabled
 
 [button]: button.md
 [special keys]: shortcuts.md#special-keys
@@ -576,7 +594,6 @@ backwards compatibility will be a priority and won’t be broken until VimFx
 
 [`Window`]: https://developer.mozilla.org/en-US/docs/Web/API/Window
 [`Browser`]: https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/browser
-[`Notification`]: https://developer.mozilla.org/en-US/docs/Web/API/Notification
 [`window.location`]: https://developer.mozilla.org/en-US/docs/Web/API/Location
 [`URL`]: https://developer.mozilla.org/en-US/docs/Web/API/URL
 [TabSelect]: https://developer.mozilla.org/en-US/docs/Web/Events/TabSelect

--- a/documentation/notifications.md
+++ b/documentation/notifications.md
@@ -1,0 +1,16 @@
+<!--
+This is part of the VimFx documentation.
+Copyright Simon Lydell 2015.
+See the file README.md for copying conditions.
+-->
+
+# Notifications
+
+Some commands may show notifications, such as the `n` and `N` commands which
+tell when they wrap around the page, or the phrase you searched for could not be
+found.
+
+VimFx’s notifications are similar to the “URL popup,” shown when hovering or
+focusing links, but is placed on the opposite side.
+
+Notifications are shown until you click them, press a key or switch tab.

--- a/documentation/options.md
+++ b/documentation/options.md
@@ -149,9 +149,13 @@ see them all in [defaults.coffee].)
 
 ### `notifications_enabled`
 
-Some commands may show a notification, such as the `n` and `N` commands which
-tell when they wrap around the page, or the phrase you searched for could not be
-found. Set this option to `false` to disable such notifications.
+Controls whether [notifications] should be shown or not.
+
+You can also choose to show notifications any way you want by listening for the
+[the `notification` and `hideNotification` events][notification-events].
+
+[notifications]: notifications.md
+[notification-events]: api.md#the-notification-and-hidenotification-events
 
 ### `prevent_target_blank`
 

--- a/extension/lib/events.coffee
+++ b/extension/lib/events.coffee
@@ -132,7 +132,12 @@ class UIEventManager
         vim.enterMode('normal')
     )
 
-    @listen('TabSelect', @vimfx.emit.bind(@vimfx, 'TabSelect'))
+    @listen('TabSelect', (event) =>
+      @vimfx.emit(@vimfx, 'TabSelect', event)
+
+      return unless vim = @vimfx.getCurrentVim(@window)
+      vim.hideNotification()
+    )
 
     @listen('TabOpen', (event) =>
       browser = @window.gBrowser.getBrowserForTab(event.originalTarget)
@@ -174,14 +179,16 @@ class UIEventManager
 
   consumeKeyEvent: (vim, event, focusType, uiEvent = false) ->
     match = vim._consumeKeyEvent(event, focusType)
-    switch
-      when not match
-        @suppress = null
-      when match.specialKeys['<late>']
+
+    if match
+      vim.hideNotification()
+      if match.specialKeys['<late>']
         @suppress = false
         @consumeLateKeydown(vim, event, match, uiEvent)
       else
         @suppress = vim._onInput(match, uiEvent)
+    else
+      @suppress = null
     @setHeldModifiers(event)
 
   consumeLateKeydown: (vim, event, match, uiEvent) ->

--- a/extension/lib/main.coffee
+++ b/extension/lib/main.coffee
@@ -30,6 +30,7 @@ modes          = require('./modes')
 options        = require('./options')
 parsePref      = require('./parse-prefs')
 prefs          = require('./prefs')
+statusPanel    = require('./status-panel')
 utils          = require('./utils')
 VimFx          = require('./vimfx')
 test           = try require('../test/index')
@@ -106,19 +107,21 @@ module.exports = (data, reason) ->
   test?(vimfx)
 
   windows = new WeakSet()
-  messageManager.listen('tabCreated', (data, {target}) ->
+  messageManager.listen('tabCreated', (data, {target: browser}) ->
     # Frame script are run in more places than we need. Tell those not to do
     # anything.
-    return false unless target.getAttribute('messagemanagergroup') == 'browsers'
+    group = browser.getAttribute('messagemanagergroup')
+    return false unless group == 'browsers'
 
-    window = target.ownerGlobal
-    vimfx.addVim(target)
+    window = browser.ownerGlobal
+    vimfx.addVim(browser)
 
     unless windows.has(window)
       windows.add(window)
       eventManager = new UIEventManager(vimfx, window)
       eventManager.addListeners(vimfx, window)
       window.document.documentElement.setAttribute('vimfx-mode', 'normal')
+      statusPanel.injectStatusPanel(browser, vimfx)
 
     return [__SCRIPT_URI_SPEC__, MULTI_PROCESS_ENABLED]
   )

--- a/extension/lib/status-panel.coffee
+++ b/extension/lib/status-panel.coffee
@@ -1,0 +1,63 @@
+###
+# Copyright Simon Lydell 2015.
+#
+# This file is part of VimFx.
+#
+# VimFx is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# VimFx is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with VimFx.  If not, see <http://www.gnu.org/licenses/>.
+###
+
+# This file creates VimFx’s status panel, similar to the “URL popup” shown when
+# hovering or focusing links.
+
+utils = require('./utils')
+
+injectStatusPanel = (browser, vimfx) ->
+  window = browser.ownerGlobal
+
+  statusPanel = window.document.createElement('statuspanel')
+  utils.setAttributes(statusPanel, {
+    inactive: 'true'
+    layer:    'true'
+    mirror:   'true'
+  })
+
+  # The current browser can usually be retrieved from `window`. However, this
+  # runs too early. Instead a browser known to exist is passed in. (_Which_
+  # browser is passed doesn’t matter since only their common container is used.)
+  window.gBrowser.getBrowserContainer(browser).appendChild(statusPanel)
+  module.onShutdown(-> statusPanel.remove())
+
+  shouldHandleNotification = (vim) ->
+    return vimfx.options.notifications_enabled and
+           vim.window == window and vim == vimfx.getCurrentVim(window)
+
+  vimfx.on('notification', ({vim, message}) ->
+    return unless shouldHandleNotification(vim)
+    statusPanel.setAttribute('label', message)
+    statusPanel.removeAttribute('inactive')
+  )
+
+  vimfx.on('hideNotification', ({vim}) ->
+    return unless shouldHandleNotification(vim)
+    statusPanel.setAttribute('inactive', 'true')
+  )
+
+  statusPanel.style.pointerEvents = 'auto'
+  utils.listen(statusPanel, 'click', ->
+    vimfx.emit('hideNotification')
+  )
+
+module.exports = {
+  injectStatusPanel
+}

--- a/extension/lib/vim.coffee
+++ b/extension/lib/vim.coffee
@@ -148,12 +148,11 @@ class Vim
   _send: (name, data, callback = null) ->
     messageManager.send(name, data, @_messageManager, callback)
 
-  notify: (title, options = {}) ->
-    return unless @options.notifications_enabled
-    new @window.Notification(title, Object.assign({
-      icon: 'chrome://vimfx/skin/icon128.png'
-      tag: 'VimFx-notification'
-    }, options))
+  notify: (message) ->
+    @_parent.emit('notification', {vim: this, message})
+
+  hideNotification: ->
+    @_parent.emit('hideNotification', {vim: this})
 
   markPageInteraction: ->
     @_send('markPageInteraction')


### PR DESCRIPTION
Users found `new Notification(message)` too intrusive. This commit shows
notifications in a `<statuspanel>` instead, like the "URL popup" (shown when
hovering or focusing links), but on the opposite side.

When pressing `n` or `N` and the search matches a link, the URL popup is shown.
Putting the VimFx notification on the opposite side allows both to be visible at
the same time.

Notifications are shown until you click them, press a key or switch tab.

See #576.