### PR TITLE
Implement marks

### DIFF
--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -118,6 +118,12 @@ letter to associate the current scroll position with that letter. For example,
 press `ma` to save the position into mark _a._ Then you can return to that
 position by pressing `` ` `` followed by the same letter, e.g. `` `a ``.
 
+One mark is special: `` ` ``. Pressing ``` `` ``` takes you to the scroll
+position before the last `gg`, `G`, `0`, `$`, `/`, `n`, `N` or `` ` ``. (You can
+change this mark using the [`last_scroll_position_mark`] pref.)
+
+[`last_scroll_position_mark`]: options.md#last_scroll_position_mark
+
 #### Minor notes
 
 Unlike Vim, you may press _any_ key after `m`, and the scroll position will be

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -111,6 +111,28 @@ eating your best hint char on most pages; see [The `f` commands]).
 
 [The `f` commands]: #the-f-commands-1
 
+### Marks: `m` and `` ` ``
+
+Other than traditional scrolling, VimFx has _marks._ Press `m` followed by a
+letter to associate the current scroll position with that letter. For example,
+press `ma` to save the position into mark _a._ Then you can return to that
+position by pressing `` ` `` followed by the same letter, e.g. `` `a ``.
+
+#### Minor notes
+
+Unlike Vim, you may press _any_ key after `m`, and the scroll position will be
+associated with that key (Vim allows only a–z, roughly).
+
+Unlike Vim and Vimium, VimFx has no global marks. The reason is that they would
+be a lot more complicated to implement and do not seem useful enough to warrant
+that effort.
+
+As mentioned above, `m` stores the _current scroll position._ Specifically, that
+means the scroll position of the element that would be scrolled if the active
+element isn't scrollable; see [Scrolling commands] above.
+
+[Scrolling commands]: #scrolling-commands-1
+
 
 ## `gi`
 

--- a/documentation/options.md
+++ b/documentation/options.md
@@ -210,6 +210,13 @@ much they scroll by adjusting the following prefs:
 (VimFx used to have a `scroll_step` pref, but is has been replaced by the
 above.)
 
+### `last_scroll_position_mark`
+
+The special mark for the [`` ` ``][scroll-to-mark] command that takes you to the
+last position.
+
+[scroll-to-mark]: commands.md#marks-m-and-
+
 ### `pattern_selector`
 
 A CSS selector that targets candidates for a previous/next page link.

--- a/documentation/shortcuts.md
+++ b/documentation/shortcuts.md
@@ -10,6 +10,7 @@ All of VimFx’s keyboard shortcuts can be customized in VimFx’s settings page
 the Add-ons Manager. Doing so is really easy. You get far just by looking at the
 defaults and trying things out. If not, read on.
 
+
 ## Key notation
 
 VimFx’s key notation is inspired by Vim’s key notation. An example:
@@ -51,6 +52,21 @@ If you’d like to know even more about the key notation, see
 
 [timeout]: options.md#timeout
 [vim-like-key-notation]: https://github.com/lydell/vim-like-key-notation
+
+
+## Tips
+
+If you use more than one keyboard layout, remember to check out the [Ignore
+keyboard layout] option.
+
+If you’d like see what VimFx interprets a key stroke as, you can (ab)use the
+[`m`] command. Press `m` followed by your desired key stroke. A [notification]
+will appear, including the interpreted key notation for that key press.
+
+[Ignore keyboard layout]: options.md#ignore-keyboard-layout
+[`m`]: commands.md#marks-m-and-
+[notification]: notifications.md
+
 
 ## Special keys
 

--- a/extension/lib/commands-frame.coffee
+++ b/extension/lib/commands-frame.coffee
@@ -62,10 +62,10 @@ commands.scroll = (args) ->
       vim.state.scrollableElements.filterSuitableDefault()
   helper_scroll(element, args)
 
-commands.mark_scroll_position = ({vim, keyStr}) ->
+commands.mark_scroll_position = ({vim, keyStr, notify = true}) ->
   element = vim.state.scrollableElements.filterSuitableDefault()
   vim.state.marks[keyStr] = [element.scrollTop, element.scrollLeft]
-  vim.notify(translate('mark_scroll_position.success', keyStr))
+  vim.notify(translate('mark_scroll_position.success', keyStr)) if notify
 
 commands.scroll_to_mark = (args) ->
   {vim, amounts: keyStr} = args

--- a/extension/lib/commands.coffee
+++ b/extension/lib/commands.coffee
@@ -115,9 +115,10 @@ commands.stop_all = ({vim}) ->
 
 
 
-helper_scroll = (vim, method, type, direction, amount, property = null) ->
-  args = {
-    method, type, direction, amount, property
+helper_scroll = (vim, args...) ->
+  [method, type, directions, amounts, properties = null, name = 'scroll'] = args
+  options = {
+    method, type, directions, amounts, properties
     smooth: (prefs.root.get('general.smoothScroll') and
              prefs.root.get("general.smoothScroll.#{type}"))
   }
@@ -125,24 +126,27 @@ helper_scroll = (vim, method, type, direction, amount, property = null) ->
     'layout.css.scroll-behavior.spring-constant',
     vim.options["smoothScroll.#{type}.spring-constant"]
   )
-  vim._run('scroll', args, reset)
+  vim._run(name, options, reset)
 
 helper_scrollByLinesX = (amount, {vim, count = 1}) ->
   distance = prefs.root.get('toolkit.scrollbox.horizontalScrollDistance')
-  helper_scroll(vim, 'scrollBy', 'lines', 'left', amount * distance * count * 5)
+  helper_scroll(vim, 'scrollBy', 'lines', ['left'],
+                [amount * distance * count * 5])
 
 helper_scrollByLinesY = (amount, {vim, count = 1}) ->
   distance = prefs.root.get('toolkit.scrollbox.verticalScrollDistance')
-  helper_scroll(vim, 'scrollBy', 'lines', 'top', amount * distance * count * 20)
+  helper_scroll(vim, 'scrollBy', 'lines', ['top'],
+                [amount * distance * count * 20])
 
 helper_scrollByPagesY = (amount, {vim, count = 1}) ->
-  helper_scroll(vim, 'scrollBy', 'pages', 'top', amount * count, 'clientHeight')
+  helper_scroll(vim, 'scrollBy', 'pages', ['top'],
+                [amount * count], ['clientHeight'])
 
 helper_scrollToX = (amount, {vim}) ->
-  helper_scroll(vim, 'scrollTo', 'other', 'left', amount, 'scrollLeftMax')
+  helper_scroll(vim, 'scrollTo', 'other', ['left'], [amount], ['scrollLeftMax'])
 
 helper_scrollToY = (amount, {vim}) ->
-  helper_scroll(vim, 'scrollTo', 'other', 'top', amount, 'scrollTopMax')
+  helper_scroll(vim, 'scrollTo', 'other', ['top'],  [amount], ['scrollTopMax'])
 
 commands.scroll_left           = helper_scrollByLinesX.bind(null, -1)
 commands.scroll_right          = helper_scrollByLinesX.bind(null, +1)
@@ -156,6 +160,15 @@ commands.scroll_to_top         = helper_scrollToY.bind(null, 0)
 commands.scroll_to_bottom      = helper_scrollToY.bind(null, Infinity)
 commands.scroll_to_left        = helper_scrollToX.bind(null, 0)
 commands.scroll_to_right       = helper_scrollToX.bind(null, Infinity)
+
+commands.mark_scroll_position = ({vim}) ->
+  vim.enterMode('marks', (keyStr) -> vim._run('mark_scroll_position', {keyStr}))
+
+commands.scroll_to_mark = ({vim}) ->
+  vim.enterMode('marks', (keyStr) ->
+    helper_scroll(vim, 'scrollTo', 'other', ['top', 'left'], keyStr,
+                  ['scrollTopMax', 'scrollLeftMax'], 'scroll_to_mark')
+  )
 
 
 

--- a/extension/lib/defaults.coffee
+++ b/extension/lib/defaults.coffee
@@ -131,6 +131,7 @@ advanced_options =
   'smoothScroll.other.spring-constant': '2500'
   'pattern_selector':                   'a, button'
   'pattern_attrs':                      'rel  role  data-tooltip  aria-label'
+  'last_scroll_position_mark':          '`'
   'hints_toggle_in_tab':                '<c-'
   'hints_toggle_in_background':         '<a-'
   'activatable_element_keys':           '<enter>'

--- a/extension/lib/defaults.coffee
+++ b/extension/lib/defaults.coffee
@@ -52,6 +52,8 @@ shortcuts =
       'G':         'scroll_to_bottom'
       '0  ^':      'scroll_to_left'
       '$':         'scroll_to_right'
+      'm':         'mark_scroll_position'
+      '`':         'scroll_to_mark'
 
     'tabs':
       't':         'tab_new'

--- a/extension/lib/modes.coffee
+++ b/extension/lib/modes.coffee
@@ -31,7 +31,7 @@ translate                  = require('./l10n')
 utils                      = require('./utils')
 
 # Helper to create modes in a DRY way.
-mode = (modeName, obj, commands) ->
+mode = (modeName, obj, commands = null) ->
   obj.name  = translate.bind(null, "mode.#{modeName}")
   obj.order = defaults.mode_order[modeName]
   obj.commands = {}
@@ -229,4 +229,20 @@ mode('find', {
 
 }, {
   exit: ({findBar}) -> findBar.close()
+})
+
+
+
+mode('marks', {
+  onEnter: ({storage}, callback) ->
+    storage.callback = callback
+
+  onLeave: ({storage}) ->
+    storage.callback = null
+
+  onInput: (args, match) ->
+    {vim, storage} = args
+    storage.callback(match.keyStr)
+    vim.enterMode('normal')
+    return true
 })

--- a/extension/lib/scrollable-elements.coffee
+++ b/extension/lib/scrollable-elements.coffee
@@ -79,15 +79,22 @@ class ScrollableElements
     @largest = null
     @elements.forEach((element) => @largest = element if @isLargest(element))
 
-  # Elements may overflow when zooming in or out. However, the `.scrollHeight`
-  # of the element is not correctly updated when the 'overflow' event occurs,
-  # making it possible for unscrollable elements to slip in. This method tells
-  # whether the largest element really is scrollable, updating it if needed.
-  hasOrUpdateLargestScrollable: ->
+  # In theory, this method could return `@largest`. In reality, it is not that
+  # simple. Elements may overflow when zooming in or out, but the
+  # `.scrollHeight` of the element is not correctly updated when the 'overflow'
+  # event occurs, making it possible for unscrollable elements to slip in. So
+  # this method has to check whether the largest element really is scrollable,
+  # and update it if needed. In the case where there is no largest element
+  # (left), it _should_ mean that the page hasn’t got any scrollable elements,
+  # and the whole page itself isn’t scrollable. However, we cannot be 100% sure
+  # that nothing is scrollable (for example, if VimFx is updated in the middle
+  # of a session). So in that case, instead of simply returning `null`, return
+  # the entire page (the best bet). Not being able to scroll is very annoying.
+  filterSuitableDefault: ->
     if @largest and @isScrollable(@largest)
-      return true
+      return @largest
     else
       @reject((element) => not @isScrollable(element))
-      return @largest?
+      return @largest ? @quirks(@window.document.documentElement)
 
 module.exports = ScrollableElements

--- a/extension/lib/vim-frame.coffee
+++ b/extension/lib/vim-frame.coffee
@@ -51,6 +51,7 @@ class VimFrame
       @state =
         hasInteraction:       false
         shouldRefocus:        false
+        marks:                {}
         lastFocusedTextInput: null
         scrollableElements:   new ScrollableElements(@content, MINIMUM_SCROLL)
         markerElements:       []

--- a/extension/lib/vimfx.coffee
+++ b/extension/lib/vimfx.coffee
@@ -51,7 +51,9 @@ class VimFx extends utils.EventEmitter
   getCurrentVim: (window) -> @vims.get(window.gBrowser.selectedBrowser)
 
   reset: (mode = null) ->
-    @currentKeyTree = if mode then @keyTrees[mode] else {}
+    # Modes without commands are returned by neither `.getGroupedCommands()` nor
+    # `createKeyTrees`. Fall back to an empty tree.
+    @currentKeyTree = @keyTrees[mode] ? {}
     @lastInputTime = 0
     @count = ''
 

--- a/extension/locale/de/vimfx.properties
+++ b/extension/locale/de/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Zum Anfang der Seite scrollen
 mode.normal.scroll_to_bottom=Zum Ende der Seite scrollen
 mode.normal.scroll_to_left=Zum linken Rand scrollen
 mode.normal.scroll_to_right=Zum rechten Rand scrollen
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=Tabs
 mode.normal.tab_new=Öffnen eines neuen leeren Tabs
@@ -91,6 +95,8 @@ mode.ignore.unquote=Einen einzigen Befehl im Normalmodus ausführen
 
 mode.find=Suchmodus
 mode.find.exit=Suchleiste schließen
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=Zeichen für Hinweise
 pref.hint_chars.desc=

--- a/extension/locale/el-GR/vimfx.properties
+++ b/extension/locale/el-GR/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Μετακινηθείτε στην κορυφή τη�
 mode.normal.scroll_to_bottom=Μετακινηθείτε στο τέλος της σελίδας
 mode.normal.scroll_to_left=Scroll to the far left
 mode.normal.scroll_to_right=Scroll to the far right
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=καρτέλες
 mode.normal.tab_new=Άνοιγμα νέας κενής καρτέλας
@@ -91,6 +95,8 @@ mode.ignore.unquote=Run one Normal mode command
 
 mode.find=Find mode
 mode.find.exit=Close find bar
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=Χαρακτήρες Δεικτών
 pref.hint_chars.desc=

--- a/extension/locale/en-US/vimfx.properties
+++ b/extension/locale/en-US/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Scroll to top
 mode.normal.scroll_to_bottom=Scroll to bottom
 mode.normal.scroll_to_left=Scroll to the far left
 mode.normal.scroll_to_right=Scroll to the far right
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=Tabs
 mode.normal.tab_new=New tab
@@ -91,6 +95,8 @@ mode.ignore.unquote=Run one Normal mode command
 
 mode.find=Find mode
 mode.find.exit=Close find bar
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=Hint chars
 pref.hint_chars.desc=

--- a/extension/locale/fr/vimfx.properties
+++ b/extension/locale/fr/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Aller en haut de la page
 mode.normal.scroll_to_bottom=Aller en bas de la page
 mode.normal.scroll_to_left=Faire défiler jusqu'au bord gauche
 mode.normal.scroll_to_right=Faire défiler jusqu'au bord droit
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=Onglets
 mode.normal.tab_new=Ouvrir un nouvel onglet
@@ -91,6 +95,8 @@ mode.ignore.unquote=Exécuter une commande en mode normal
 
 mode.find=Mode recherche
 mode.find.exit=Fermer la barre de recherche
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=Marqueurs de liens
 pref.hint_chars.desc=

--- a/extension/locale/hu/vimfx.properties
+++ b/extension/locale/hu/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Ugrás az oldal tetejére
 mode.normal.scroll_to_bottom=Ugrás az oldal aljára
 mode.normal.scroll_to_left=Scroll to the far left
 mode.normal.scroll_to_right=Scroll to the far right
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=Tab
 mode.normal.tab_new=Új tab nyitása
@@ -91,6 +95,8 @@ mode.ignore.unquote=Run one Normal mode command
 
 mode.find=Find mode
 mode.find.exit=Close find bar
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=Segéd karakterek
 pref.hint_chars.desc=

--- a/extension/locale/id/vimfx.properties
+++ b/extension/locale/id/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Gulung ke puncak
 mode.normal.scroll_to_bottom=Gulung ke dasar
 mode.normal.scroll_to_left=Gulung ke paling kiri
 mode.normal.scroll_to_right=Gulung ke paling kanan
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=Tab
 mode.normal.tab_new=Tab baru
@@ -91,6 +95,8 @@ mode.ignore.unquote=Jalankan satu perintah mode Normal
 
 mode.find=Mode Cari
 mode.find.exit=Tutup bar Cari
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=Karakter Petunjuk
 pref.hint_chars.desc=

--- a/extension/locale/it/vimfx.properties
+++ b/extension/locale/it/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Scorri all'inizio della pagina
 mode.normal.scroll_to_bottom=Scorri alla fine della pagina
 mode.normal.scroll_to_left=Scorri all'estrema sinistra
 mode.normal.scroll_to_right=Scorri all'estrema destra
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=Schede (tab)
 mode.normal.tab_new=Apri una nuova scheda
@@ -91,6 +95,8 @@ mode.ignore.unquote=Esegui un comando della modalità normale
 
 mode.find=Modalità trova
 mode.find.exit=Chiudi la barra di ricerca
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=Caratteri di suggerimento
 pref.hint_chars.desc=

--- a/extension/locale/ja/vimfx.properties
+++ b/extension/locale/ja/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=ページの最上部へスクロール
 mode.normal.scroll_to_bottom=ページの最下部へスクロール
 mode.normal.scroll_to_left=左へスクロール
 mode.normal.scroll_to_right=右へスクロール
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=タブの操作
 mode.normal.tab_new=新規タブを開く
@@ -91,6 +95,8 @@ mode.ignore.unquote=ノーマルモードのコマンドを一度限り実行
 
 mode.find=検索モード
 mode.find.exit=検索バーを閉じる
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=ヒント機能で使用する文字
 pref.hint_chars.desc=

--- a/extension/locale/nl/vimfx.properties
+++ b/extension/locale/nl/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Scroll naar de bovenkant
 mode.normal.scroll_to_bottom=Scroll naar de onderkant
 mode.normal.scroll_to_left=Scroll helemaal naar links
 mode.normal.scroll_to_right=Scroll helemaal naar rechts
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=Tabbladen
 mode.normal.tab_new=Open een nieuw tabblad
@@ -91,6 +95,8 @@ mode.ignore.unquote=Voer een commando uit in normale modus
 
 mode.find=Zoekmodus
 mode.find.exit=Sluit zoekbalk
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=Gebruikte karakters
 pref.hint_chars.desc=

--- a/extension/locale/pl/vimfx.properties
+++ b/extension/locale/pl/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Przewiń na górę strony
 mode.normal.scroll_to_bottom=Przewin na dół strony
 mode.normal.scroll_to_left=Scroll to the far left
 mode.normal.scroll_to_right=Scroll to the far right
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=Karty
 mode.normal.tab_new=Otwórz nową kartę
@@ -91,6 +95,8 @@ mode.ignore.unquote=Run one Normal mode command
 
 mode.find=Find mode
 mode.find.exit=Close find bar
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=Znaki podpowiedzi
 pref.hint_chars.desc=

--- a/extension/locale/pt-BR/vimfx.properties
+++ b/extension/locale/pt-BR/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Rolar até o topo
 mode.normal.scroll_to_bottom=Rolar até o fim
 mode.normal.scroll_to_left=Rolar para a esquerda até o fim
 mode.normal.scroll_to_right=Rolar para a direita até o fim
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=Abas
 mode.normal.tab_new=Nova aba
@@ -91,6 +95,8 @@ mode.ignore.unquote=Executar um comando no modo Normal
 
 mode.find=Modo de Busca
 mode.find.exit=Fechar barra de busca
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=Caracteres de Sugestão
 pref.hint_chars.desc=

--- a/extension/locale/ru/vimfx.properties
+++ b/extension/locale/ru/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Прокрутить к верху страницы
 mode.normal.scroll_to_bottom=Прокрутить к низу страницы
 mode.normal.scroll_to_left=Прокрутить влево до конца
 mode.normal.scroll_to_right=Прокрутить вправо до конца
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=Вкладки
 mode.normal.tab_new=Открыть новую вкладку
@@ -91,6 +95,8 @@ mode.ignore.unquote=Выполнить одну команду в нормаль
 
 mode.find=Режим поиска
 mode.find.exit=Закрыть панель поиска
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=Символы на маркерах
 pref.hint_chars.desc=

--- a/extension/locale/sv-SE/vimfx.properties
+++ b/extension/locale/sv-SE/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=Scrolla högst upp
 mode.normal.scroll_to_bottom=Scrolla längst ned
 mode.normal.scroll_to_left=Scrolla längst till vänster
 mode.normal.scroll_to_right=Scroll längst till höger
+mode.normal.mark_scroll_position=Markera scrollposition
+mark_scroll_position.success=Markör satt: %S
+mode.normal.scroll_to_mark=Scrolla till markör
+scroll_to_mark.error=Ingen markör för: %S
 
 category.tabs=Flikar
 mode.normal.tab_new=Ny flik
@@ -91,6 +95,8 @@ mode.ignore.unquote=Kör ett Normallägeskommando
 
 mode.find=Sökläge
 mode.find.exit=Stäng sökpanelen
+
+mode.marks=Markörläge
 
 pref.hint_chars.title=Etikettstecken
 pref.hint_chars.desc=

--- a/extension/locale/zh-CN/vimfx.properties
+++ b/extension/locale/zh-CN/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=滚动到页面顶部
 mode.normal.scroll_to_bottom=滚动到页面底部
 mode.normal.scroll_to_left=滚动到最左边
 mode.normal.scroll_to_right=滚动到最右边
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=标签页
 mode.normal.tab_new=新建标签页
@@ -91,6 +95,8 @@ mode.ignore.unquote=执行一个普通模式下的命令
 
 mode.find=查找模式
 mode.find.exit=关闭查找栏
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=提示符
 pref.hint_chars.desc=

--- a/extension/locale/zh-TW/vimfx.properties
+++ b/extension/locale/zh-TW/vimfx.properties
@@ -37,6 +37,10 @@ mode.normal.scroll_to_top=捲動到網頁最頂端
 mode.normal.scroll_to_bottom=捲動到網頁最末端
 mode.normal.scroll_to_left=捲動到網頁最左端
 mode.normal.scroll_to_right=捲動到網頁最右端
+mode.normal.mark_scroll_position=Mark scroll position
+mark_scroll_position.success=Mark set: %S
+mode.normal.scroll_to_mark=Scroll to mark
+scroll_to_mark.error=No mark for: %S
 
 category.tabs=分頁
 mode.normal.tab_new=開新分頁
@@ -91,6 +95,8 @@ mode.ignore.unquote=執行一個正常模式下的指令
 
 mode.find=搜尋模式
 mode.find.exit=關閉搜尋列
+
+mode.marks=Marks mode
 
 pref.hint_chars.title=提示字元（Hint Chars）
 pref.hint_chars.desc=進入 Hints 模式時，用哪些符號進行標記。


### PR DESCRIPTION
This is what Vimium supports:

```
ma, mA  set local mark "a" (global mark "A")
`a, `A  jump to local mark "a" (global mark "A")
``      jump back to the position before the previous jump
          -- that is, before the previous gg, G, n, N, / or `a
```

So far, all marks are treated as local. No global ones, no jump back.

See #434.

Note to self: Should probably store marks in main process, not in frame scripts (to be able to support global marks).