### PR TITLE
Fix misplaced devtools hint markers when zoomed

### DIFF
--- a/extension/lib/marker.coffee
+++ b/extension/lib/marker.coffee
@@ -46,15 +46,14 @@ class Marker
   setPosition: (viewport, zoom) ->
     {
       markerElement: {clientHeight: height, clientWidth: width}
-      elementShape:  {nonCoveredPoint: {x: left, y: top, offset, rect}}
+      elementShape:  {nonCoveredPoint: {x: left, y: top, offset}}
     } = this
+
+    height /= zoom
+    width  /= zoom
 
     # Center the marker vertically on the non-covered point.
     top -= Math.ceil(height / 2)
-
-    # Make sure that the marker stays within its element (vertically).
-    top = Math.min(top, rect.bottom - height)
-    top = Math.max(top, rect.top)
 
     # Make the position relative to the top frame.
     left += offset.left

--- a/extension/lib/modes.coffee
+++ b/extension/lib/modes.coffee
@@ -93,8 +93,8 @@ mode('normal', {
     if uiEvent
       # In browser UI the biggest reasons are allowing to reset the location bar
       # when blurring it, and closing dialogs such as the “bookmark this page”
-      # dialog (<c-d>). However, an exception is made for the dev tools (<c-K>).
-      # There, trying to unfocus the dev tools using Escape would annoyingly
+      # dialog (<c-d>). However, an exception is made for the devtools (<c-K>).
+      # There, trying to unfocus the devtools using Escape would annoyingly
       # open the split console.
       return uiEvent.originalTarget.ownerGlobal.DevTools?
     else


### PR DESCRIPTION
See #667.

- [x] Zoom in
- [x] Zoom out—I have no idea why this doesn’t work currently. EDIT: Seems to work _somewhat_ well when zooming out just a little bit. Perhaps it doesn't matter: The important thing is that zooming _in_ works. – Edit 2: Always properly now.
- [x] Cleanup