### PR TITLE
Recognize more elements as clickable

### DIFF
--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -25,6 +25,8 @@ nsIClipboardHelper = Cc['@mozilla.org/widget/clipboardhelper;1']
   .getService(Ci.nsIClipboardHelper)
 nsIDomUtils = Cc['@mozilla.org/inspector/dom-utils;1']
   .getService(Ci.inIDOMUtils)
+nsIEventListenerService = Cc['@mozilla.org/eventlistenerservice;1']
+  .getService(Ci.nsIEventListenerService)
 nsIFocusManager = Cc['@mozilla.org/focus-manager;1']
   .getService(Ci.nsIFocusManager)
 nsIStyleSheetService = Cc['@mozilla.org/content/style-sheet-service;1']
@@ -338,6 +340,13 @@ class EventEmitter
 
 has = (obj, prop) -> Object::hasOwnProperty.call(obj, prop)
 
+# Check if `search` exists in `string` (case insensitively). Returns `false` if
+# `string` doesn’t exist or isn’t a string, such as `<SVG element>.className`.
+includes = (string, search) ->
+  return false unless typeof string == 'string'
+  return string.toLowerCase().includes(search)
+
+
 nextTick = (window, fn) -> window.setTimeout(fn, 0)
 
 regexEscape = (s) -> s.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
@@ -378,6 +387,12 @@ getCurrentLocation = ->
   return new window.URL(window.gBrowser.selectedBrowser.currentURI.spec)
 
 getCurrentWindow = -> nsIWindowMediator.getMostRecentWindow('navigator:browser')
+
+hasEventListeners = (element, type) ->
+  for listener in nsIEventListenerService.getListenerInfoFor(element)
+    if listener.listenerObject and listener.type == type
+      return true
+  return false
 
 loadCss = (name) ->
   uri = Services.io.newURI("chrome://vimfx/skin/#{name}.css", null, null)
@@ -447,6 +462,7 @@ module.exports = {
   Counter
   EventEmitter
   has
+  includes
   nextTick
   regexEscape
   removeDuplicates
@@ -456,6 +472,7 @@ module.exports = {
   formatError
   getCurrentLocation
   getCurrentWindow
+  hasEventListeners
   loadCss
   observe
   openPopup


### PR DESCRIPTION
- Elements with `data-` attributes used for clickable things by Bootstrap are
  now recognized. This is a huge win since Bootstrap is very popular and many
  developers use it with semantically unclickable elements (even though the
  Bootstrap documentation always reminds of accessibility concerns). Since these
  elements are or _should have been_ semantically clickable elements, they are
  always treated as such, in order not to give them too bad hints.

- A few `aria-` attributes are now recognized as semantically clickable.

- ARIA roles are now treated as _semantically_ clickable, instead of just
  clickable.

- "Close" buttons are now attempted to be recognized. This is useful for many of
  those obtrusive EU cookie law notices. Recognizing Bootstrap elements also
  helps greatly here.

- Finally, elements with 'click' event listeners (added using
  `element.addEventListener('click', ...)`) are now recognized, by using a
  Firefox API. This is really useful on DuckDuckGo's image search. Fixes #671,
  and fixes #672.

  Note that event delegation is not supported, since that would require
  inspecting the code of the event listeners. One _could_ inspect the global
  `jQuery` object (if any) to get to solve that problem to a great extent (like
  Firefox's devtools do), but I'm not sure if that's a good idea.

It should also be noted that I tried recognizing elements matching
`/\bjs-/.test(element.className)`, but that proved give too many false
positives.