### PR TITLE
Fix `__dirname` variable on Windows

### DIFF
--- a/extension/lib/config.coffee
+++ b/extension/lib/config.coffee
@@ -53,7 +53,7 @@ loadFile = (dir, file, scope) ->
   try
     Services.scriptloader.loadSubScriptWithOptions(uri, {
       target: Object.assign({
-        __dirname: OS.Path.dirname(uri)
+        __dirname: OS.Path.toFileURI(utils.expandPath(dir))
       }, scope)
       charset: 'UTF-8'
       ignoreCache: true


### PR DESCRIPTION
OS.Path.dirname does not support FileURI on Windows,
OS.Path.dirname('file:///C:/Users/foo/.vimfx/config.js') return 'file:'.