### PR TITLE
Hide unless hint on Twitter which covers hint for new tweets

### DIFF
--- a/extension/lib/commands-frame.coffee
+++ b/extension/lib/commands-frame.coffee
@@ -259,6 +259,8 @@ commands.follow = helper_follow.bind(
             utils.includes(element.getAttribute?('aria-label'), 'close') or
             # Do this last as it’s a potentially expensive check.
             utils.hasEventListeners(element, 'click'))
+        # on Twitter, the hint for this element covers the actual hint
+        return null if element.classList?.contains('js-new-items-bar-container')
         # Make a quick check for likely clickable descendants, to reduce the
         # number of false positives. the element might be a “button-wrapper” or
         # a large element with a click-tracking event listener.


### PR DESCRIPTION
On Twitter VimFx shows two hints for the "x new tweets" banner, one for the container and one for the only child.
Clicking on the container does not do anything, but the hint for it often cover the hint which would actually load the tweets.

The patch removes the useless hint on Twitter. Alternatively the heuristics for checking for clickable descendants could be change to exclude the element if it has `container` in one of it's class. That change would be more general, but it might break hinting for some other sites. Thoughts?