### PR TITLE
Dispatch trusted mouse events to content page

### DIFF
--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -44,9 +44,9 @@ XULControlElement = Ci.nsIDOMXULControlElement
 XULMenuListElement = Ci.nsIDOMXULMenuListElement
 XULTextBoxElement = Ci.nsIDOMXULTextBoxElement
 
-# Full chains of events for different mouse actions. Note: 'mouseup' is actually
-# fired before 'click'!
-EVENTS_CLICK       = ['mousedown', 'mouseup', 'click']
+# Full chains of events for different mouse actions. Note: 'click' is fired
+# by Firefox automatically after 'mousedown' and 'mouseup'
+EVENTS_CLICK       = ['mousedown', 'mouseup']
 EVENTS_CLICK_XUL   = ['click', 'command']
 EVENTS_HOVER_START = ['mouseover', 'mouseenter', 'mousemove']
 EVENTS_HOVER_END   = ['mouseout',  'mouseleave']
@@ -315,7 +315,9 @@ simulateMouseEvents = (element, sequence) ->
       screenX: window.screenX + rect.left
       screenY: window.screenY + rect.top
     })
-    element.dispatchEvent(mouseEvent)
+    window.QueryInterface(Ci.nsIInterfaceRequestor)
+      .getInterface(Ci.nsIDOMWindowUtils)
+      .dispatchDOMEventViaPresShell(element, mouseEvent, true)
 
   return
 


### PR DESCRIPTION
Some DOM APIs need to be called from the handler of a trusted event to
work. `requestFullscreen()` and `document.execCommand('copy')` are
examples of such API.

Before this patch, VimFx dispatched mouse events using
`element.dispatchEvent()` which had the event handlers for the events
running in untrusted context. This behavior prevented hint mode from
full-screening on Youtube and copying clone addresses on Github.

This patch uses XPCOM to dispatch mouse events as trusted events to the
content page.

See also:
https://www.w3.org/TR/uievents/#trusted-events - info from the spec
https://clipboardjs.com/ - before this patch, copying doesn't work

--

As a side note, right now full screening on Youtube works in Vimium but not in VimFx