### PR TITLE
Support clicking file input elements

### DIFF
--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -147,7 +147,7 @@ isProperLink = (element) ->
 
 isTextInputElement = (element) ->
   return (element.localName == 'input' and element.type in [
-           'text', 'search', 'tel', 'url', 'email', 'password', 'number'
+           'text', 'search', 'tel', 'url', 'email', 'password', 'number', 'file'
          ]) or
          element.localName == 'textarea' or
          element instanceof XULTextBoxElement or


### PR DESCRIPTION
Currently, input file selectors of the type

```
<input type="file">
```

are not detected by VimFx. I think this may be the simple change needed to detect these elements and make them clickable.