### PR TITLE
Fix `zF` double clicking on elements

### DIFF
--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -46,9 +46,10 @@ XULMenuListElement = Ci.nsIDOMXULMenuListElement
 XULTextBoxElement = Ci.nsIDOMXULTextBoxElement
 
 # Full chains of events for different mouse actions. Note: 'click' is fired
-# by Firefox automatically after 'mousedown' and 'mouseup'.
+# by Firefox automatically after 'mousedown' and 'mouseup'. Similarly,
+# 'command' is fired automatically after 'click' on xul pages.
 EVENTS_CLICK       = ['mousedown', 'mouseup']
-EVENTS_CLICK_XUL   = ['click', 'command']
+EVENTS_CLICK_XUL   = ['click']
 EVENTS_HOVER_START = ['mouseover', 'mouseenter', 'mousemove']
 EVENTS_HOVER_END   = ['mouseout',  'mouseleave']
 


### PR DESCRIPTION
nsIDOMWindowUtils.dispatchDOMEventViaPresShell() dispatches
a 'command' event automatically after a 'click' event on XUL pages.
This was causing zF to effectively double click on browser elements,
since VimFx also simulate a 'command' event.

Elements which suffers from this double click include but not limited
to, the new tab button, question mark bubbles in the preference page
and buttons created by the add-on sdk.