### PR TITLE
Leave trailing slash when going up path

### DIFF
--- a/extension/lib/commands-frame.coffee
+++ b/extension/lib/commands-frame.coffee
@@ -59,7 +59,7 @@ commands = {}
 
 commands.go_up_path = ({vim, count = 1}) ->
   {pathname}  = vim.content.location
-  newPathname = pathname.replace(/// (?: /[^/]+ ){1,#{count}} /?$ ///, '')
+  newPathname = pathname.replace(/// (?: [^/]+ (/|$)){1,#{count}} $ ///, '')
   if newPathname == pathname
     vim.notify(translate('notification.go_up_path.limit'))
   else


### PR DESCRIPTION
VimFx removes trailing slash when going up path with `gu`, and caused problems on some servers thinking that an URL without a trailing slash doesn't point to a directory (try `gu` on e.g. https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/).