### PR TITLE
Pentadactyl hints

### DIFF
--- a/extension/lib/commands-frame.coffee
+++ b/extension/lib/commands-frame.coffee
@@ -162,8 +162,9 @@ helper_follow = (options, matcher, {vim, pass}) ->
     return unless shape.nonCoveredPoint
 
     originalRect = element.getBoundingClientRect()
+    text = utils.getText(element)
     length = vim.state.markerElements.push({element, originalRect})
-    wrapper = {type, shape, elementIndex: length - 1}
+    wrapper = {type, shape, text, elementIndex: length - 1}
 
     if wrapper.type == 'link'
       {href} = element

--- a/extension/lib/commands.coffee
+++ b/extension/lib/commands.coffee
@@ -622,8 +622,9 @@ commands.click_browser_element = ({vim}) ->
     shape = getElementShape(element)
     return unless shape.nonCoveredPoint
 
+    text = utils.getText(element)
     length = markerElements.push(element)
-    return {type, shape, elementIndex: length - 1}
+    return {type, shape, text, elementIndex: length - 1}
 
   callback = (marker) ->
     element = markerElements[marker.wrapper.elementIndex]

--- a/extension/lib/defaults.coffee
+++ b/extension/lib/defaults.coffee
@@ -153,6 +153,7 @@ shortcuts =
 
 options =
   'hint_chars':             'fjdkslaghrueiwonc mv'
+  'text_hint_selection':    false
   'prev_patterns':          'prev  previous  ‹  «  ◀  ←  <<  <  back  newer'
   'next_patterns':          'next  ›  »  ▶  →  >>  >  more  older'
   'blacklist':              '*example.com*  http://example.org/editor/*'

--- a/extension/lib/events.coffee
+++ b/extension/lib/events.coffee
@@ -204,6 +204,10 @@ class UIEventManager
       vim._enterMode('normal')
 
   consumeKeyEvent: (vim, event) ->
+    if vim.eatingKeys
+      @suppress = true
+      return
+
     match = vim._consumeKeyEvent(event)
 
     if match

--- a/extension/lib/marker-container.coffee
+++ b/extension/lib/marker-container.coffee
@@ -254,23 +254,23 @@ class MarkerContainer
     return matchedMarkers
 
   deleteHintChar: ->
-    if @numEnteredChars > 0
-      for marker in @markers
-        switch marker.hintIndex - @numEnteredChars
-          when 0
-            marker.deleteHintChar()
-          when -1
-            marker.show()
-      @numEnteredChars -= 1
-    else
-      matchedMarkers = []
-      for marker in @markers
-        if marker.isComplementary == @isComplementary
-          marker.deleteTextChar()
-          if marker.matchesText()
-            marker.show()
-            matchedMarkers.push(marker)
-      @recalculateHintsWithPasses(matchedMarkers, @markerMap)
+    for marker in @markers
+      switch marker.hintIndex - @numEnteredChars
+        when 0
+          marker.deleteHintChar()
+        when -1
+          marker.show()
+    @numEnteredChars -= 1 unless @numEnteredChars == 0
+
+  deleteTextChar: ->
+    matchedMarkers = []
+    for marker in @markers
+      if marker.isComplementary == @isComplementary
+        marker.deleteTextChar()
+        if marker.matchesText()
+          marker.show()
+          matchedMarkers.push(marker)
+    @recalculateHintsWithPasses(matchedMarkers, @markerMap)
 
   clearHintChars: ->
     @deleteHintChar() while @numEnteredChars > 0

--- a/extension/lib/marker-container.coffee
+++ b/extension/lib/marker-container.coffee
@@ -246,8 +246,10 @@ class MarkerContainer
 
     @recalculateHintsWithPasses(matchedMarkers, @markerMap)
 
-    if matchedMarkers.length == 1
-      matchedMarkers[0].markMatched(true)
+    markers = matchedMarkers.filter((marker) -> not marker.wrapper.parentIndex?)
+
+    if markers.length == 1
+      markers[0].markMatched(true)
     else
       matchedMarkers = []
 

--- a/extension/lib/marker-container.coffee
+++ b/extension/lib/marker-container.coffee
@@ -64,7 +64,7 @@ class MarkerContainer
 
   reset: ->
     @numEnteredChars = 0
-    marker.reset() for marker in @markers when marker.hintIndex > 0
+    marker.reset() for marker in @markers when marker.hintIndex > 0 || marker.textChars != ""
     @refreshComplementaryVisiblity()
 
   refreshComplementaryVisiblity: ->

--- a/extension/lib/marker-container.coffee
+++ b/extension/lib/marker-container.coffee
@@ -219,7 +219,8 @@ class MarkerContainer
 
     for marker in @markers
       if marker.isComplementary == @isComplementary and
-         marker.hintIndex == @numEnteredChars
+         marker.hintIndex == @numEnteredChars and
+         marker.visible
         matched = marker.matchHintChar(char)
         marker.hide() unless matched
         if marker.isMatched()

--- a/extension/lib/marker-container.coffee
+++ b/extension/lib/marker-container.coffee
@@ -66,12 +66,26 @@ class MarkerContainer
     @numEnteredChars = 0
     marker.reset() for marker in @markers when marker.hintIndex > 0 || marker.textChars != ""
     @refreshComplementaryVisiblity()
-    @recalculateHints(
-      @markers.filter((marker) -> !marker.wrapper.parentIndex?),
-      @markers.filter((marker) -> marker.wrapper.parentIndex?),
-      @markerMap,
-      "reset"
-    )
+    if @markers.find((marker) -> marker.pass == "first" || marker.pass == "second")
+      @recalculateHints(
+        @markers.filter((marker) -> marker.pass != "second" && !marker.wrapper.parentIndex?),
+        @markers.filter((marker) -> marker.pass != "second" && marker.wrapper.parentIndex?),
+        @markerMap,
+        "first"
+      )
+      @recalculateHints(
+        @markers.filter((marker) -> marker.pass == "second" && !marker.wrapper.parentIndex?),
+        @markers.filter((marker) -> marker.pass == "second" && marker.wrapper.parentIndex?),
+        @markerMap,
+        "second"
+      )
+    else
+      @recalculateHints(
+        @markers.filter((marker) -> !marker.wrapper.parentIndex?),
+        @markers.filter((marker) -> marker.wrapper.parentIndex?),
+        @markerMap,
+        "reset"
+      )
 
   refreshComplementaryVisiblity: ->
     for marker in @markers
@@ -89,7 +103,7 @@ class MarkerContainer
     markerMap = {}
 
     for wrapper in wrappers
-      marker = new Marker(wrapper, @window.document, {isComplementary})
+      marker = new Marker(wrapper, @window.document, {isComplementary, pass})
       if wrapper.parentIndex?
         combined.push(marker)
       else

--- a/extension/lib/marker-container.coffee
+++ b/extension/lib/marker-container.coffee
@@ -64,7 +64,8 @@ class MarkerContainer
 
   reset: ->
     @numEnteredChars = 0
-    marker.reset() for marker in @markers when marker.hintIndex > 0 || marker.textChars != ""
+    for marker in @markers when marker.hintIndex > 0 || marker.textChars != ""
+      marker.reset()
     @refreshComplementaryVisiblity()
     @recalculateHintsWithPasses(@markers, @markerMap)
 

--- a/extension/lib/marker-container.coffee
+++ b/extension/lib/marker-container.coffee
@@ -66,6 +66,12 @@ class MarkerContainer
     @numEnteredChars = 0
     marker.reset() for marker in @markers when marker.hintIndex > 0 || marker.textChars != ""
     @refreshComplementaryVisiblity()
+    @recalculateHints(
+      @markers.filter((marker) -> !marker.wrapper.parentIndex?),
+      @markers.filter((marker) -> marker.wrapper.parentIndex?),
+      @markerMap,
+      "reset"
+    )
 
   refreshComplementaryVisiblity: ->
     for marker in @markers

--- a/extension/lib/marker-container.coffee
+++ b/extension/lib/marker-container.coffee
@@ -64,7 +64,7 @@ class MarkerContainer
 
   reset: ->
     @numEnteredChars = 0
-    for marker in @markers when marker.hintIndex > 0 || marker.textChars != ""
+    for marker in @markers when marker.hintIndex > 0 or marker.textChars != ''
       marker.reset()
     @refreshComplementaryVisiblity()
     @recalculateHintsWithPasses(@markers, @markerMap)
@@ -133,7 +133,7 @@ class MarkerContainer
     Object.assign(@markerMap, markerMap)
 
   recalculateHints: (allMarkers, markerMap, pass) ->
-    markers = allMarkers.filter((marker) -> !marker.wrapper.parentIndex?)
+    markers = allMarkers.filter((marker) -> not marker.wrapper.parentIndex?)
     combined = allMarkers.filter((marker) -> marker.wrapper.parentIndex?)
     prefixes = switch pass
       when 'first'
@@ -181,20 +181,20 @@ class MarkerContainer
 
   recalculateHintsWithPasses: (markers, markerMap) ->
     wasTwoPass = (marker) ->
-      marker.pass = "first" || marker.pass == "second"
+      marker.pass = 'first' or marker.pass == 'second'
     if markers.find((marker) -> wasTwoPass(marker))
       @recalculateHints(
-        markers.filter((marker) -> marker.pass != "second"),
+        markers.filter((marker) -> marker.pass != 'second'),
         markerMap,
-        "first"
+        'first'
       )
       @recalculateHints(
-        markers.filter((marker) -> marker.pass == "second"),
+        markers.filter((marker) -> marker.pass == 'second'),
         markerMap,
-        "second"
+        'second'
       )
     else
-      @recalculateHints(markers, markerMap, "single")
+      @recalculateHints(markers, markerMap, 'single')
 
   toggleComplementary: ->
     if not @isComplementary and not @hasLookedForComplementaryWrappers

--- a/extension/lib/marker-container.coffee
+++ b/extension/lib/marker-container.coffee
@@ -206,6 +206,24 @@ class MarkerContainer
     @numEnteredChars += 1
     return matchedMarkers
 
+  matchTextChar: (char) ->
+    matchedMarkers = []
+
+    for marker in @markers
+      if marker.isComplementary == @isComplementary
+        matched = marker.matchTextChar(char)
+        if matched
+          matchedMarkers.push(marker)
+        else
+          marker.hide()
+
+    if matchedMarkers.length == 1
+      matchedMarkers[0].markMatched(true)
+    else
+      matchedMarkers = []
+
+    return matchedMarkers
+
   deleteHintChar: ->
     for marker in @markers
       switch marker.hintIndex - @numEnteredChars

--- a/extension/lib/marker.coffee
+++ b/extension/lib/marker.coffee
@@ -34,7 +34,9 @@ class Marker
     @width = 0
     @height = 0
     @hint = ''
+    @text = @wrapper.text
     @hintIndex = 0
+    @textChars = ''
     @visible = true
     @zoom = 1
     @viewport = null
@@ -109,6 +111,10 @@ class Marker
       @hintIndex += 1
       return true
     return false
+
+  matchTextChar: (char) ->
+    @textChars += char
+    return @text.indexOf(@textChars) != -1
 
   deleteHintChar: ->
     if @hintIndex > 0

--- a/extension/lib/marker.coffee
+++ b/extension/lib/marker.coffee
@@ -26,7 +26,7 @@ utils = require('./utils')
 class Marker
   # `@wrapper` is a stand-in for the element that the marker represents. See
   # `MarkerContainer::injectHints` for more information.
-  constructor: (@wrapper, @document, {@isComplementary}) ->
+  constructor: (@wrapper, @document, {@isComplementary, @pass}) ->
     @elementShape  = @wrapper.shape
     @markerElement = utils.createBox(@document, 'marker')
     @markerElement.setAttribute('data-type', @wrapper.type)

--- a/extension/lib/marker.coffee
+++ b/extension/lib/marker.coffee
@@ -34,7 +34,7 @@ class Marker
     @width = 0
     @height = 0
     @hint = ''
-    @text = @wrapper.text
+    @text = @wrapper.text.toLowerCase()
     @hintIndex = 0
     @textChars = ''
     @visible = true
@@ -113,7 +113,7 @@ class Marker
     return false
 
   matchTextChar: (char) ->
-    @textChars += char
+    @textChars += char.toLowerCase()
     return @text.indexOf(@textChars) != -1
 
   deleteHintChar: ->

--- a/extension/lib/marker.coffee
+++ b/extension/lib/marker.coffee
@@ -113,14 +113,19 @@ class Marker
       return true
     return false
 
-  matchTextChar: (char) ->
+  addTextChar: (char) ->
     @textChars += char.toLowerCase()
+
+  matchesText: ->
     return @text.indexOf(@textChars) != -1
 
   deleteHintChar: ->
     if @hintIndex > 0
       @hintIndex -= 1
       @toggleLastHintChar(false)
+
+  deleteTextChar: ->
+    @textChars = @textChars.slice(0, -1)
 
   toggleLastHintChar: (visible) ->
     @markerElement.children[@hintIndex]

--- a/extension/lib/marker.coffee
+++ b/extension/lib/marker.coffee
@@ -45,6 +45,7 @@ class Marker
 
   reset: ->
     @setHint(@hint)
+    @textChars = ''
     @show()
 
   show: -> @setVisibility(true)

--- a/extension/lib/modes.coffee
+++ b/extension/lib/modes.coffee
@@ -197,6 +197,7 @@ mode('hints', {
     storage.markerContainer = markerContainer
     storage.callback = callback
     storage.count = count
+    storage.textChars = ''
 
     if sleep >= 0
       storage.clearInterval = utils.interval(vim.window, sleep, (next) ->
@@ -244,6 +245,9 @@ mode('hints', {
           vim._enterMode('normal') if vim.mode == 'hints'
     else
       matchedMarkers = markerContainer.matchTextChar(match.unmodifiedKey)
+      storage.textChars += match.unmodifiedKey
+      if vim.options.notify_entered_keys
+        vim.notify(storage.textChars)
       if matchedMarkers.length > 0
         again = callback(matchedMarkers[0], storage.count, match.keyStr)
         storage.count -= 1
@@ -273,8 +277,11 @@ mode('hints', {
   rotate_markers_backward: ({storage}) ->
     storage.markerContainer.rotateOverlapping(false)
 
-  delete_hint_char: ({storage}) ->
+  delete_hint_char: ({vim, storage}) ->
     storage.markerContainer.deleteHintChar()
+    storage.textChars = storage.textChars.slice(0, -1)
+    if vim.options.notify_entered_keys
+      vim.notify(storage.textChars) if storage.textChars.length > 0
 
   increase_count: ({storage}) ->
     storage.count += 1

--- a/extension/lib/modes.coffee
+++ b/extension/lib/modes.coffee
@@ -245,8 +245,10 @@ mode('hints', {
           # mode if we’re still in Hints mode.
           vim._enterMode('normal') if vim.mode == 'hints'
     else if vim.options.text_hint_selection
-      matchedMarkers = markerContainer.matchTextChar(match.unmodifiedKey)
-      storage.textChars += match.unmodifiedKey
+      key = match.unmodifiedKey
+      key = ' ' if key == 'space'
+      matchedMarkers = markerContainer.matchTextChar(key)
+      storage.textChars += key
       if matchedMarkers.length > 0
         again = callback(matchedMarkers[0], storage.count, match.keyStr)
         storage.count -= 1

--- a/extension/lib/modes.coffee
+++ b/extension/lib/modes.coffee
@@ -233,6 +233,7 @@ mode('hints', {
       if matchedMarkers.length > 0
         again = callback(matchedMarkers[0], storage.count, match.keyStr)
         storage.count -= 1
+        storage.textChars = ''
         if again
           vim.window.setTimeout((->
             marker.markMatched(false) for marker in matchedMarkers
@@ -246,11 +247,10 @@ mode('hints', {
     else
       matchedMarkers = markerContainer.matchTextChar(match.unmodifiedKey)
       storage.textChars += match.unmodifiedKey
-      if vim.options.notify_entered_keys
-        vim.notify(storage.textChars)
       if matchedMarkers.length > 0
         again = callback(matchedMarkers[0], storage.count, match.keyStr)
         storage.count -= 1
+        storage.textChars = ''
         if again
           vim.window.setTimeout((->
             marker.markMatched(false) for marker in matchedMarkers
@@ -262,6 +262,8 @@ mode('hints', {
           # mode if we’re still in Hints mode.
           vim._enterMode('normal') if vim.mode == 'hints'
 
+    if vim.options.notify_entered_keys
+      vim.notify(storage.textChars) if storage.textChars
     return true
 
 }, {
@@ -277,17 +279,16 @@ mode('hints', {
   rotate_markers_backward: ({storage}) ->
     storage.markerContainer.rotateOverlapping(false)
 
-  delete_hint_char: ({vim, storage}) ->
+  delete_hint_char: ({storage}) ->
     storage.markerContainer.deleteHintChar()
     storage.textChars = storage.textChars.slice(0, -1)
-    if vim.options.notify_entered_keys
-      vim.notify(storage.textChars) if storage.textChars.length > 0
 
   increase_count: ({storage}) ->
     storage.count += 1
 
   toggle_complementary: ({storage}) ->
     storage.markerContainer.toggleComplementary()
+    storage.textChars = ''
 })
 
 

--- a/extension/lib/modes.coffee
+++ b/extension/lib/modes.coffee
@@ -244,7 +244,7 @@ mode('hints', {
           # The callback might have entered another mode. Only go back to Normal
           # mode if we’re still in Hints mode.
           vim._enterMode('normal') if vim.mode == 'hints'
-    else
+    else if vim.options.text_hint_selection
       matchedMarkers = markerContainer.matchTextChar(match.unmodifiedKey)
       storage.textChars += match.unmodifiedKey
       if matchedMarkers.length > 0
@@ -280,10 +280,10 @@ mode('hints', {
   rotate_markers_backward: ({storage}) ->
     storage.markerContainer.rotateOverlapping(false)
 
-  delete_hint_char: ({storage}) ->
+  delete_hint_char: ({vim, storage}) ->
     if storage.markerContainer.numEnteredChars > 0
       storage.markerContainer.deleteHintChar()
-    else
+    else if vim.options.text_hint_selection
       storage.markerContainer.deleteTextChar()
       storage.textChars = storage.textChars.slice(0, -1)
 

--- a/extension/lib/modes.coffee
+++ b/extension/lib/modes.coffee
@@ -251,6 +251,7 @@ mode('hints', {
         again = callback(matchedMarkers[0], storage.count, match.keyStr)
         storage.count -= 1
         storage.textChars = ''
+        vim.eatKeys(vim.options.hints_timeout)
         if again
           vim.window.setTimeout((->
             marker.markMatched(false) for marker in matchedMarkers

--- a/extension/lib/modes.coffee
+++ b/extension/lib/modes.coffee
@@ -242,6 +242,21 @@ mode('hints', {
           # The callback might have entered another mode. Only go back to Normal
           # mode if we’re still in Hints mode.
           vim._enterMode('normal') if vim.mode == 'hints'
+    else
+      matchedMarkers = markerContainer.matchTextChar(match.unmodifiedKey)
+      if matchedMarkers.length > 0
+        again = callback(matchedMarkers[0], storage.count, match.keyStr)
+        storage.count -= 1
+        if again
+          vim.window.setTimeout((->
+            marker.markMatched(false) for marker in matchedMarkers
+            return
+          ), vim.options.hints_timeout)
+          markerContainer.reset()
+        else
+          # The callback might have entered another mode. Only go back to Normal
+          # mode if we’re still in Hints mode.
+          vim._enterMode('normal') if vim.mode == 'hints'
 
     return true
 

--- a/extension/lib/modes.coffee
+++ b/extension/lib/modes.coffee
@@ -280,8 +280,11 @@ mode('hints', {
     storage.markerContainer.rotateOverlapping(false)
 
   delete_hint_char: ({storage}) ->
-    storage.markerContainer.deleteHintChar()
-    storage.textChars = storage.textChars.slice(0, -1)
+    if storage.markerContainer.numEnteredChars > 0
+      storage.markerContainer.deleteHintChar()
+    else
+      storage.markerContainer.deleteTextChar()
+      storage.textChars = storage.textChars.slice(0, -1)
 
   increase_count: ({storage}) ->
     storage.count += 1

--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -239,9 +239,9 @@ getFocusType = (element) -> switch
 
 getText = (element) -> switch
   when isTextInputElement(element)
-    element.value || element.placeholder || ""
+    element.value or element.placeholder or ''
   else
-    element.innerText || ""
+    element.innerText or ''
 
 
 

--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -237,9 +237,11 @@ getFocusType = (element) -> switch
   else
     'none'
 
-getText = (element) ->
-  # XXX do a more intelligent thing here for input, images, etc
-  return element.innerText
+getText = (element) -> switch
+  when isTextInputElement(element)
+    element.value || element.placeholder || ""
+  else
+    element.innerText || ""
 
 
 

--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -237,6 +237,10 @@ getFocusType = (element) -> switch
   else
     'none'
 
+getText = (element) ->
+  # XXX do a more intelligent thing here for input, images, etc
+  return element.innerText
+
 
 
 # Event helpers
@@ -603,6 +607,7 @@ module.exports = {
   blurActiveBrowserElement
   focusElement
   getFocusType
+  getText
 
   listen
   listenOnce

--- a/extension/lib/vim.coffee
+++ b/extension/lib/vim.coffee
@@ -35,6 +35,7 @@ class Vim
   constructor: (browser, @_parent) ->
     @mode = undefined
     @focusType = 'none'
+    @eatingKeys = false
     @_setBrowser(browser, {addListeners: false})
     @_storage = {}
 
@@ -121,6 +122,13 @@ class Vim
 
   _consumeKeyEvent: (event) ->
     return @_parent.consumeKeyEvent(event, this)
+
+  eatKeys: (timeout) ->
+    @eatingKeys = true
+    vim = this
+    @window.setTimeout((->
+      vim.eatingKeys = false
+    ), timeout)
 
   _onInput: (match, event) ->
     uiEvent = if @isUIEvent(event) then event else false

--- a/extension/locale/en-US/vimfx.properties
+++ b/extension/locale/en-US/vimfx.properties
@@ -160,6 +160,9 @@ notification.copy_selection_and_exit.none=No text selection to copy
 pref.hint_chars.title=Hint chars
 pref.hint_chars.desc=
 
+pref.text_hint_selection.title=Select hints using text
+pref.text_hint_selection.desc=Allow selecting hints by typing a substring of the text contained in the hinted element.\nNote: you likely want to set the hint chars to non-letter characters to use this mode.
+
 pref.blacklist.title=Blacklist
 pref.blacklist.desc=List of URLs where VimFx should automatically enter Ignore mode. Use spaces as delimiter and * as a wildcard.
 


### PR DESCRIPTION
This is an attempt at fixing #340. It's not complete yet (I haven't updated the documentation, squashed commits, etc), but I wanted to get an idea of if this looks plausible, since it's my first time writing CoffeeScript or Firefox plugins.

Some immediate questions that come to mind:
- I decided to keep it permanently enabled, since it doesn't actually interfere with using hints mode by just typing hint characters (since it prefers matching hint characters to matching the text). Is this reasonable, or would there be too much confusion if someone accidentally typed a key that wasn't a hint char? I'm also fine with putting it behind an option, or as a separate mode entirely.
- Is it reasonable to reuse the `hint_timeout` option for the length of time to suppress key input after a successful match (see the last commit), or should that be its own option?
- I wasn't able to get the test suite to work, since as of Firefox 48, loading unsigned addons is no longer supported, and so I was unable to get the Extension Auto-Installer extension to do anything (I just tested by hand using the "Load Temporary Add-on" button in `about:debugging`). Is there another way to run tests?

I'd also be interested in any other feedback you have. Let me know what you think, and I can get the branch cleaned up once it's ready to merge.