### PR TITLE
Update for Firefox 58.

### DIFF
--- a/extension/lib/prefs.coffee
+++ b/extension/lib/prefs.coffee
@@ -23,7 +23,7 @@ get = (branch, key) ->
     when branch.PREF_INT
       branch.getIntPref(key)
     when branch.PREF_STRING
-      branch.getComplexValue(key, Ci.nsISupportsString).data
+      branch.getCharPref(key)
 
 set = (branch, key, value) ->
   switch typeof value
@@ -32,10 +32,7 @@ set = (branch, key, value) ->
     when 'number'
       branch.setIntPref(key, value) # `value` will be `Math.floor`ed.
     when 'string'
-      str = Cc['@mozilla.org/supports-string;1']
-        .createInstance(Ci.nsISupportsString)
-      str.data = value
-      branch.setComplexValue(key, Ci.nsISupportsString, str)
+      branch.setCharPref(key, value)
     else
       if value == null
         branch.clearUserPref(key)


### PR DESCRIPTION
(This allows running in Firefox 58 with legacy extensions enabled.)

It appears that the complex pref API was removed, throwing an error on
use. This changes the code to use setCharPref which is ASCII only. I
don't know if there is a better solution at the moment.
