### PR TITLE
support for nsPrefBranch::{get,set}StringPref()

### DIFF
--- a/extension/lib/prefs.coffee
+++ b/extension/lib/prefs.coffee
@@ -23,7 +23,10 @@ get = (branch, key) ->
     when branch.PREF_INT
       branch.getIntPref(key)
     when branch.PREF_STRING
-      branch.getComplexValue(key, Ci.nsISupportsString).data
+      if branch.getStringPref
+        branch.getStringPref(key)
+      else
+        branch.getComplexValue(key, Ci.nsISupportsString).data
 
 set = (branch, key, value) ->
   switch typeof value
@@ -32,10 +35,13 @@ set = (branch, key, value) ->
     when 'number'
       branch.setIntPref(key, value) # `value` will be `Math.floor`ed.
     when 'string'
-      str = Cc['@mozilla.org/supports-string;1']
-        .createInstance(Ci.nsISupportsString)
-      str.data = value
-      branch.setComplexValue(key, Ci.nsISupportsString, str)
+      if branch.setStringPref
+        branch.setStringPref(key, value)
+      else
+        str = Cc['@mozilla.org/supports-string;1']
+          .createInstance(Ci.nsISupportsString)
+        str.data = value
+        branch.setComplexValue(key, Ci.nsISupportsString, str)
     else
       if value == null
         branch.clearUserPref(key)


### PR DESCRIPTION
This fixes for Firefox >= 2017-11-10.

Firefox commit:

--8<--

Bug 1414096 (attempt 2) - Remove support for nsISupportsString values in nsPrefBranch::{get,set}ComplexValue(). r=florian.

Bug 1345294 introduced nsPrefBranch::{get,set}StringPref(), which allowed the
getting of utf8 strings from prefs, which previously required using
nsISupportsString with {get,set}ComplexValue. That bug also converted most
uses.

This patch finishes the job.

- It removes the nsISupportsString support.
- It converts existing code that relied on the nsISupportsString.
- It removes the lint that was set up to detect such uses of nsISupportsString.

-->8--
