### PR TITLE
Work around changes introduced in upstream bug 888600

### DIFF
--- a/extension/lib/message-manager.coffee
+++ b/extension/lib/message-manager.coffee
@@ -5,12 +5,16 @@
 
 namespace = (name, prefix) -> "#{ADDON_PATH}/#{BUILD_TIME}/#{prefix}#{name}"
 
-defaultMessageManager =
-  if IS_FRAME_SCRIPT
-    FRAME_SCRIPT_ENVIRONMENT
-  else
-    Cc['@mozilla.org/globalmessagemanager;1']
-      .getService(Ci.nsIMessageListenerManager)
+try
+  defaultMessageManager =
+    if IS_FRAME_SCRIPT
+      FRAME_SCRIPT_ENVIRONMENT
+    else
+      Cc['@mozilla.org/globalmessagemanager;1']
+        .getService(Ci.nsIMessageListenerManager)
+catch error
+  defaultMessageManager =
+    Cc['@mozilla.org/globalmessagemanager;1'].getService()
 
 defaultOptions = {
   messageManager: defaultMessageManager


### PR DESCRIPTION
I'm still using VimFx together with current Firefox versions.
There are some breaking changes in this upstream commit:
https://hg.mozilla.org/mozilla-central/rev/243246b2f440

This commit is linked to this bug report:
https://bugzilla.mozilla.org/show_bug.cgi?id=888600

I've tried to workaround it by using the new syntax if the old one fails. I'm not sure if this is the right approach, but VimFx works for me again in Firefox nightly.