### PR TITLE
Fix VimFx on Firefox 61

### DIFF
--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -28,7 +28,6 @@ nsIDomUtils =
 XULButtonElement = Ci.nsIDOMXULButtonElement
 XULControlElement = Ci.nsIDOMXULControlElement
 XULMenuListElement = Ci.nsIDOMXULMenuListElement
-XULTextBoxElement = Ci.nsIDOMXULTextBoxElement
 
 isXULDocument = (doc) ->
   doc.toString() == '[object XULDocument]'
@@ -155,8 +154,7 @@ isTextInputElement = (element) ->
   return (element.localName == 'input' and element.type in [
            'text', 'search', 'tel', 'url', 'email', 'password', 'number'
          ]) or
-         element.localName == 'textarea' or
-         element instanceof XULTextBoxElement or
+         element.localName in [ 'textarea', 'textbox' ] or
          isContentEditable(element)
 
 isTypingElement = (element) ->


### PR DESCRIPTION
This makes VimFx work on FFDeveloper Edition 61.0b2.

It was removed: https://bugzilla.mozilla.org/show_bug.cgi?id=1456703

I replaced it with the same logic used when replacing it in
mozilla-central.

This file might be interesting to watch if future interfaces get
removed: https://dxr.mozilla.org/mozilla-central/source/dom/interfaces/xul/moz.build