### PR TITLE
Add content variable back to frame scope.

### DIFF
--- a/extension/lib/main-frame.coffee
+++ b/extension/lib/main-frame.coffee
@@ -29,7 +29,10 @@ module.exports = ->
 
   loadConfig = ->
     configDir = prefs.get('config_file_directory')
-    scope = {vimfx: createConfigAPI(vim, onShutdown)}
+    scope = {
+      vimfx: createConfigAPI(vim, onShutdown)
+      content: content
+    }
     error = config.loadFile(configDir, 'frame.js', scope)
     return error
 

--- a/extension/lib/main-frame.coffee
+++ b/extension/lib/main-frame.coffee
@@ -31,7 +31,7 @@ module.exports = ->
     configDir = prefs.get('config_file_directory')
     scope = {
       vimfx: createConfigAPI(vim, onShutdown)
-      content: content
+      content
     }
     error = config.loadFile(configDir, 'frame.js', scope)
     return error


### PR DESCRIPTION
This used to exist but was removed in recent versions of firefox. This
adds it back.