### PR TITLE
fix: use new pinned tab property

### DIFF
--- a/extension/lib/commands.coffee
+++ b/extension/lib/commands.coffee
@@ -311,7 +311,7 @@ absoluteTabIndex = (relativeIndex, gBrowser, {pinnedSeparate}) ->
   currentIndex = tabs.indexOf(selectedTab)
   absoluteIndex = currentIndex + relativeIndex
   numTabsTotal = tabs.length
-  numPinnedTabs = gBrowser._numPinnedTabs
+  numPinnedTabs = gBrowser.pinnedTabCount ? gBrowser._numPinnedTabs # fx132
 
   [numTabs, min] = switch
     when not pinnedSeparate
@@ -396,7 +396,8 @@ commands.tab_select_first = ({vim, count = 1}) ->
   )
 
 commands.tab_select_first_non_pinned = ({vim, count = 1}) ->
-  firstNonPinned = vim.window.gBrowser._numPinnedTabs
+  gBrowser = vim.window.gBrowser
+  firstNonPinned = gBrowser.pinnedTabCount ? gBrowser._numPinnedTabs # fx132
   utils.nextTick(vim.window, ->
     vim.window.gBrowser.selectTabAtIndex(firstNonPinned + count - 1)
   )


### PR DESCRIPTION
noticed `g^` that accounted for number of pinned tabs stopped working with latest VimFx in Firefox Developer Edition 133.0b6.

After `console.log` printing the `gBrowser` object I found it seems to list the previous `_numPinnedTabs` property as `undefined` and `pinnedTabCount` now filled in so did a codebase-wide `s/_numPinnedTabs/pinnedTabCount`.

Seems to work for me in custom functions, would appreciate another opinion to test/confirm worthy of upstreaming.

Thanks!