### PR TITLE
fix: prevent_autofocus silently broken since Firefox ~90

### DIFF
--- a/extension/lib/events-frame.coffee
+++ b/extension/lib/events-frame.coffee
@@ -241,12 +241,13 @@ class FrameEventManager
       )
 
       # Blur the focus target, if autofocus prevention is enabled…
+      focusMask = nsIFocusManager.METHOD_MASK & ~nsIFocusManager.FLAG_BYJS
       if options.prevent_autofocus and
          @vim.mode in options.prevent_autofocus_modes and
          # …and the user has interacted with the page…
          not @vim.state.hasInteraction and
          # …and the event is programmatic (not caused by clicks or keypresses)…
-         nsIFocusManager.getLastFocusMethod(null) == 0 and
+         (nsIFocusManager.getLastFocusMethod(null) & focusMask) == 0 and
          # …and the target may steal most keystrokes
          utils.isTypingElement(target)
         # Some sites (such as icloud.com) re-focuses inputs if they are blurred,


### PR DESCRIPTION
## Problem

The `prevent_autofocus` option was broken for me on modern Firefox for a long while already (roughly since Fx 90, mid-2021).

The autofocus prevention in `events-frame.coffee` relies on this check:

```coffee
nsIFocusManager.getLastFocusMethod(null) == 0
```

The assumption was that `getLastFocusMethod()` returns `0` for any programmatic focus (autofocus attribute, `element.focus()`, etc.) and only returns nonzero for user-initiated focus (mouse, keyboard, tab movement).

[Mozilla bug 1712724](https://bugzilla.mozilla.org/show_bug.cgi?id=1712724) changed `nsFocusManager::ProgrammaticFocusFlags()` from returning `0` to returning the new `FLAG_BYJS` (`0x400000`). This means `getLastFocusMethod()` now returns `0x400000` for every programmatic focus, and the `== 0` check is always false. The `target.blur()` branch is unreachable.

## Fix

Replace the exact-equality check with a bitmask test against the user-input flags only (defined by internal METHOD_MASK with FLAG_BYJS excluded):

```coffee
(nsIFocusManager.getLastFocusMethod(null) & (nsIFocusManager.METHOD_MASK & ~nsIFocusManager.FLAG_BYJS)) == 0
```

If none of the user-input bits are set, the focus is programmatic and should be prevented. This restores the original intent without relying on a specific return value for the non-user-input case.

## Testing

- Tested manually on Firefox 150 (Linux): enabled `prevent_autofocus`, confirmed autofocus is prevented on page load (DuckDuckGo, etc.) and that clicking to focus inputs still works.
- Not tested on Fx 115 (the minimum supported version). All flags used in the mask predate Fx 115, so there should be no compatibility issue.
- CoffeeScript compilation verified against `coffeescript@1.12.7`.

## Disclosure

The root cause analysis and initial patch were produced with LLM assistance. I reviewed and tested the fix manually.